### PR TITLE
Optimize contracts and drop user sets

### DIFF
--- a/src/LBErrors.sol
+++ b/src/LBErrors.sol
@@ -79,7 +79,6 @@ error LBFactory__ImplementationNotSet();
 error LBPair__InsufficientAmounts();
 error LBPair__AddressZero();
 error LBPair__AddressZeroOrThis();
-error LBPair__BrokenSwapSafetyCheck();
 error LBPair__CompositionFactorFlawed(uint256 id);
 error LBPair__InsufficientLiquidityMinted(uint256 id);
 error LBPair__InsufficientLiquidityBurned(uint256 id);

--- a/src/LBErrors.sol
+++ b/src/LBErrors.sol
@@ -89,18 +89,16 @@ error LBPair__OnlyFactory();
 error LBPair__DistributionsOverflow();
 error LBPair__OnlyFeeRecipient(address feeRecipient, address sender);
 error LBPair__OracleNotEnoughSample();
-error LBPair__FlashLoanCallbackFailed();
 error LBPair__AlreadyInitialized();
 error LBPair__NewSizeTooSmall(uint256 newSize, uint256 oracleSize);
+error LBPair__FlashLoanCallbackFailed();
+error LBPair__FlashLoanWrongFee();
+error LBPair__FlashLoanTokenNotSupported();
 
 /** BinHelper errors */
 
 error BinHelper__BinStepOverflows(uint256 bp);
 error BinHelper__IdOverflows();
-
-/** FeeDistributionHelper errors */
-
-error FeeDistributionHelper__FlashLoanWrongFee(uint256 receivedFee, uint256 expectedFee);
 
 /** Math128x128 errors */
 

--- a/src/LBPair.sol
+++ b/src/LBPair.sol
@@ -434,8 +434,8 @@ contract LBPair is LBToken, ReentrancyGuardUpgradeable, ILBPair {
         uint256 _amount,
         bytes calldata _data
     ) external override nonReentrant {
-        (IERC20 _tokenX, IERC20 _tokenY) = (tokenX, tokenY);
-        if ((_token != tokenX && _token != tokenY)) revert LBPair__FlashLoanTokenNotSupported();
+        IERC20 _tokenX = tokenX;
+        if ((_token != _tokenX && _token != tokenY)) revert LBPair__FlashLoanTokenNotSupported();
 
         uint256 _totalFee = _getFlashLoanFee(_amount);
 

--- a/src/LBPair.sol
+++ b/src/LBPair.sol
@@ -427,7 +427,7 @@ contract LBPair is LBToken, ReentrancyGuardUpgradeable, ILBPair {
     /// @param _receiver the address that will receive the flash loan and execute the call back
     /// @param _token The address of the token
     /// @param _amount The amount of token
-    /// @param _data The call data that will be forwarder to `_receiver` during the callback
+    /// @param _data The call data that will be forwarded to `_receiver` during the callback
     function flashLoan(
         ILBFlashLoanCallback _receiver,
         IERC20 _token,

--- a/src/LBPair.sol
+++ b/src/LBPair.sol
@@ -349,33 +349,16 @@ contract LBPair is LBToken, ReentrancyGuardUpgradeable, ILBPair {
 
                 _bins[_pair.activeId] = _bin;
 
-                if (_swapForY) {
-                    emit Swap(
-                        msg.sender,
-                        _to,
-                        _pair.activeId,
-                        _amountInToBin,
-                        0,
-                        0,
-                        _amountOutOfBin,
-                        _fp.volatilityAccumulated,
-                        _fees.total,
-                        0
-                    );
-                } else {
-                    emit Swap(
-                        msg.sender,
-                        _to,
-                        _pair.activeId,
-                        0,
-                        _amountInToBin,
-                        _amountOutOfBin,
-                        0,
-                        _fp.volatilityAccumulated,
-                        0,
-                        _fees.total
-                    );
-                }
+                // Avoids stack too deep error
+                _emitSwap(
+                    _to,
+                    _pair.activeId,
+                    _swapForY,
+                    _amountInToBin,
+                    _amountOutOfBin,
+                    _fp.volatilityAccumulated,
+                    _fees.total
+                );
             }
 
             if (_amountIn != 0) {
@@ -1070,5 +1053,26 @@ contract LBPair is LBToken, ReentrancyGuardUpgradeable, ILBPair {
         assembly {
             sstore(_pairFees.slot, and(shl(_OFFSET_PROTOCOL_FEE, _protocolFees), _totalFees))
         }
+    }
+
+    function _emitSwap(
+        address _to,
+        uint24 _activeId,
+        bool _swapForY,
+        uint256 _amountInToBin,
+        uint256 _amountOutOfBin,
+        uint256 _volatilityAccumulated,
+        uint256 _fees
+    ) private {
+        emit Swap(
+            msg.sender,
+            _to,
+            _activeId,
+            _swapForY,
+            _amountInToBin,
+            _amountOutOfBin,
+            _volatilityAccumulated,
+            _fees
+        );
     }
 }

--- a/src/LBPair.sol
+++ b/src/LBPair.sol
@@ -368,8 +368,6 @@ contract LBPair is LBToken, ReentrancyGuardUpgradeable, ILBPair {
             }
         }
 
-        if (_amountOut == 0) revert LBPair__BrokenSwapSafetyCheck(); // Safety check
-
         // We use oracleSize so it can start filling empty slot that were added recently
         uint256 _updatedOracleId = _oracle.update(
             _pair.oracleSize,

--- a/src/LBPair.sol
+++ b/src/LBPair.sol
@@ -299,7 +299,7 @@ contract LBPair is LBToken, ReentrancyGuardUpgradeable, ILBPair {
     /// @param _interfaceId The interface identifier
     /// @return Whether the interface is supported (true) or not (false)
     function supportsInterface(bytes4 _interfaceId) public view override returns (bool) {
-        return _interfaceId == type(ILBPair).interfaceId || super.supportsInterface(_interfaceId);
+        return super.supportsInterface(_interfaceId) || _interfaceId == type(ILBPair).interfaceId;
     }
 
     /** External Functions **/

--- a/src/LBRouter.sol
+++ b/src/LBRouter.sol
@@ -642,7 +642,7 @@ contract LBRouter is ILBRouter {
     /// @param _LBPair LBPair where liquidity is deposited
     /// @return depositIds Bin ids where the liquidity was actually deposited
     /// @return liquidityMinted Amounts of LBToken minted for each bin
-    function _addLiquidity(LiquidityParameters memory _liq, ILBPair _LBPair)
+    function _addLiquidity(LiquidityParameters calldata _liq, ILBPair _LBPair)
         private
         ensure(_liq.deadline)
         returns (uint256[] memory depositIds, uint256[] memory liquidityMinted)

--- a/src/LBToken.sol
+++ b/src/LBToken.sol
@@ -293,7 +293,7 @@ contract LBToken is ILBToken {
             mstore(0x00, selectorERC165)
             mstore(0x04, ILBTokenInterfaceId)
 
-            let success := eq(staticcall(30000, _target, 0x00, 0x24, 0x00, 0x20), 1)
+            let success := staticcall(30000, _target, 0x00, 0x24, 0x00, 0x20)
             let size := eq(returndatasize(), 0x20)
             let data := eq(mload(0x00), 1)
 

--- a/src/interfaces/ILBFlashLoanCallback.sol
+++ b/src/interfaces/ILBFlashLoanCallback.sol
@@ -2,16 +2,17 @@
 
 pragma solidity 0.8.10;
 
+import "openzeppelin/token/ERC20/IERC20.sol";
+
 /// @title Liquidity Book Flashloan Callback Interface
 /// @author Trader Joe
-/// @notice Required interface to interact with LB flashloans
+/// @notice Required interface to interact with LB flash loans
 interface ILBFlashLoanCallback {
     function LBFlashLoanCallback(
         address sender,
-        uint256 amountX,
-        uint256 amountY,
-        uint256 feeX,
-        uint256 feeY,
-        bytes memory data
-    ) external;
+        IERC20 token,
+        uint256 amount,
+        uint256 fee,
+        bytes calldata data
+    ) external returns (bytes32);
 }

--- a/src/interfaces/ILBPair.sol
+++ b/src/interfaces/ILBPair.sol
@@ -99,14 +99,12 @@ interface ILBPair {
     event Swap(
         address indexed sender,
         address indexed recipient,
-        uint24 indexed id,
-        uint256 amountXIn,
-        uint256 amountYIn,
-        uint256 amountXOut,
-        uint256 amountYOut,
+        uint256 indexed id,
+        bool swapForY,
+        uint256 amountIn,
+        uint256 amountOut,
         uint256 volatilityAccumulated,
-        uint256 feesX,
-        uint256 feesY
+        uint256 fees
     );
 
     event FlashLoan(

--- a/src/interfaces/ILBPair.sol
+++ b/src/interfaces/ILBPair.sol
@@ -6,6 +6,7 @@ import "openzeppelin/token/ERC20/IERC20.sol";
 
 import "../libraries/FeeHelper.sol";
 import "./ILBFactory.sol";
+import "./ILBFlashLoanCallback.sol";
 
 /// @title Liquidity Book Pair Interface
 /// @author Trader Joe
@@ -110,11 +111,10 @@ interface ILBPair {
 
     event FlashLoan(
         address indexed sender,
-        address indexed recipient,
-        uint256 amountX,
-        uint256 amountY,
-        uint256 feesX,
-        uint256 feesY
+        ILBFlashLoanCallback indexed receiver,
+        IERC20 token,
+        uint256 amount,
+        uint256 fee
     );
 
     event LiquidityAdded(
@@ -212,10 +212,10 @@ interface ILBPair {
     function swap(bool sentTokenY, address to) external returns (uint256 amountXOut, uint256 amountYOut);
 
     function flashLoan(
-        address to,
-        uint256 amountXOut,
-        uint256 amountYOut,
-        bytes memory data
+        ILBFlashLoanCallback receiver,
+        IERC20 token,
+        uint256 amount,
+        bytes calldata data
     ) external;
 
     function mint(

--- a/src/interfaces/ILBPair.sol
+++ b/src/interfaces/ILBPair.sol
@@ -115,17 +115,6 @@ interface ILBPair {
         uint256 fee
     );
 
-    event LiquidityAdded(
-        address indexed sender,
-        address indexed recipient,
-        uint256 indexed id,
-        uint256 minted,
-        uint256 amountX,
-        uint256 amountY,
-        uint256 distributionX,
-        uint256 distributionY
-    );
-
     event CompositionFee(
         address indexed sender,
         address indexed recipient,
@@ -134,14 +123,23 @@ interface ILBPair {
         uint256 feesY
     );
 
-    event LiquidityRemoved(
+    event DepositedToBin(
         address indexed sender,
         address indexed recipient,
         uint256 indexed id,
-        uint256 burned,
         uint256 amountX,
         uint256 amountY
     );
+
+    event WithdrawnFromBin(
+        address indexed sender,
+        address indexed recipient,
+        uint256 indexed id,
+        uint256 amountX,
+        uint256 amountY
+    );
+
+    event Burn(address indexed sender, address indexed recipient, uint256 amountX, uint256 amountY);
 
     event FeesCollected(address indexed sender, address indexed recipient, uint256 amountX, uint256 amountY);
 

--- a/src/interfaces/ILBPair.sol
+++ b/src/interfaces/ILBPair.sol
@@ -170,10 +170,10 @@ interface ILBPair {
         external
         view
         returns (
-            uint256 feesXTotal,
-            uint256 feesYTotal,
-            uint256 feesXProtocol,
-            uint256 feesYProtocol
+            uint128 feesXTotal,
+            uint128 feesYTotal,
+            uint128 feesXProtocol,
+            uint128 feesYProtocol
         );
 
     function getOracleParameters()
@@ -241,7 +241,7 @@ interface ILBPair {
 
     function collectFees(address account, uint256[] calldata ids) external returns (uint256 amountX, uint256 amountY);
 
-    function collectProtocolFees() external returns (uint256 amountX, uint256 amountY);
+    function collectProtocolFees() external returns (uint128 amountX, uint128 amountY);
 
     function setFeesParameters(bytes32 packedFeeParameters) external;
 

--- a/src/interfaces/ILBPair.sol
+++ b/src/interfaces/ILBPair.sol
@@ -139,8 +139,6 @@ interface ILBPair {
         uint256 amountY
     );
 
-    event Burn(address indexed sender, address indexed recipient, uint256 amountX, uint256 amountY);
-
     event FeesCollected(address indexed sender, address indexed recipient, uint256 amountX, uint256 amountY);
 
     event ProtocolFeesCollected(address indexed sender, address indexed recipient, uint256 amountX, uint256 amountY);

--- a/src/interfaces/ILBToken.sol
+++ b/src/interfaces/ILBToken.sol
@@ -31,10 +31,6 @@ interface ILBToken is IERC165 {
         view
         returns (uint256[] memory batchBalances);
 
-    function userPositionAtIndex(address account, uint256 index) external view returns (uint256);
-
-    function userPositionNumber(address account) external view returns (uint256);
-
     function totalSupply(uint256 id) external view returns (uint256);
 
     function isApprovedForAll(address owner, address spender) external view returns (bool);

--- a/src/libraries/Constants.sol
+++ b/src/libraries/Constants.sol
@@ -11,4 +11,7 @@ library Constants {
 
     uint256 internal constant PRECISION = 1e18;
     uint256 internal constant BASIS_POINT_MAX = 10_000;
+
+    /// @dev The expected return after a successful flash loan
+    bytes32 internal constant CALLBACK_SUCCESS = keccak256("ERC3156FlashBorrower.onFlashLoan");
 }

--- a/src/libraries/FeeDistributionHelper.sol
+++ b/src/libraries/FeeDistributionHelper.sol
@@ -2,47 +2,14 @@
 
 pragma solidity 0.8.10;
 
-import "openzeppelin/token/ERC20/IERC20.sol";
-
 import "../LBErrors.sol";
 import "./Constants.sol";
 import "./FeeHelper.sol";
-import "./SafeCast.sol";
-import "./TokenHelper.sol";
 
 /// @title Liquidity Book Fee Distribution Helper Library
 /// @author Trader Joe
 /// @notice Helper contract used for fees distribution calculations
 library FeeDistributionHelper {
-    using TokenHelper for IERC20;
-    using SafeCast for uint256;
-
-    /// @notice Checks that the flash loan was done accordingly and update fees
-    /// @param _fees The fees received by the pair
-    /// @param _pairFees The fees of the pair
-    /// @param _token The address of the token received
-    /// @param _reserve The stored reserve of the current bin
-    function flashLoanHelper(
-        FeeHelper.FeesDistribution memory _fees,
-        FeeHelper.FeesDistribution storage _pairFees,
-        IERC20 _token,
-        uint256 _reserve
-    ) internal {
-        uint128 _totalFees = _pairFees.total;
-        uint256 _amountReceived = _token.received(_reserve, _totalFees);
-
-        if (_amountReceived != _fees.total)
-            revert FeeDistributionHelper__FlashLoanWrongFee(_amountReceived, _fees.total);
-
-        _fees.total = _amountReceived.safe128();
-
-        _pairFees.total = _totalFees + _fees.total;
-        // unsafe math is fine because total >= protocol
-        unchecked {
-            _pairFees.protocol += _fees.protocol;
-        }
-    }
-
     /// @notice Calculate the tokenPerShare when fees are added
     /// @param _fees The fees received by the pair
     /// @param _totalSupply the total supply of a specific bin

--- a/src/libraries/TokenHelper.sol
+++ b/src/libraries/TokenHelper.sol
@@ -75,7 +75,7 @@ library TokenHelper {
     /// @param target The address of the account
     /// @param data The data to execute on `target`
     /// @return returnData The data returned by the call
-    function _callAndCatchError(address target, bytes memory data) private returns (bytes memory returnData) {
+    function _callAndCatchError(address target, bytes memory data) private returns (bytes memory) {
         (bool success, bytes memory returnData) = target.call(data);
 
         if (success) {
@@ -89,6 +89,8 @@ library TokenHelper {
                 }
             }
         }
+
+        return returnData;
     }
 
     /// @notice Private view function to return if an address is a contract

--- a/test/LBPair.t.sol
+++ b/test/LBPair.t.sol
@@ -27,79 +27,85 @@ contract LiquidityBinPairTest is TestHelper {
     }
 
     function testMintWrongLengthsReverts() public {
-        uint256[] memory _deltaIds;
+        uint256[] memory _ids;
         uint256[] memory _distributionX;
         uint256[] memory _distributionY;
         uint256 _numberBins = 0;
-        _deltaIds = new uint256[](_numberBins);
+        _ids = new uint256[](_numberBins);
         _distributionX = new uint256[](_numberBins);
         _distributionY = new uint256[](_numberBins);
 
         vm.expectRevert(LBPair__WrongLengths.selector);
-        pair.mint(_deltaIds, _distributionX, _distributionY, DEV);
+        pair.mint(_ids, _distributionX, _distributionY, DEV);
         _numberBins = 2;
-        _deltaIds = new uint256[](_numberBins);
+        _ids = new uint256[](_numberBins);
         _distributionX = new uint256[](_numberBins - 1);
         _distributionY = new uint256[](_numberBins);
         vm.expectRevert(LBPair__WrongLengths.selector);
-        pair.mint(_deltaIds, _distributionX, _distributionY, DEV);
+        pair.mint(_ids, _distributionX, _distributionY, DEV);
         _distributionX = new uint256[](_numberBins);
         _distributionY = new uint256[](_numberBins - 1);
         vm.expectRevert(LBPair__WrongLengths.selector);
-        pair.mint(_deltaIds, _distributionX, _distributionY, DEV);
+        pair.mint(_ids, _distributionX, _distributionY, DEV);
     }
 
     function testDistributionOverflowReverts() public {
         uint256 amount = 10e18;
         token6D.mint(address(pair), amount);
         token18D.mint(address(pair), amount);
-        uint256[] memory _deltaIds;
+        uint256[] memory _ids;
         uint256[] memory _distributionX;
         uint256[] memory _distributionY;
         uint256 _numberBins = 1;
-        _deltaIds = new uint256[](_numberBins);
+        _ids = new uint256[](_numberBins);
         _distributionX = new uint256[](_numberBins);
+        _distributionY = new uint256[](_numberBins);
+
+        _ids[0] = ID_ONE;
+
         _distributionY = new uint256[](_numberBins);
         _distributionX[0] = Constants.PRECISION + 1;
         vm.expectRevert(LBPair__DistributionsOverflow.selector);
-        pair.mint(_deltaIds, _distributionX, _distributionY, DEV);
+        pair.mint(_ids, _distributionX, _distributionY, DEV);
 
         _distributionX[0] = 0;
         _distributionY[0] = Constants.PRECISION + 1;
         vm.expectRevert(LBPair__DistributionsOverflow.selector);
-        pair.mint(_deltaIds, _distributionX, _distributionY, DEV);
+        pair.mint(_ids, _distributionX, _distributionY, DEV);
 
         _numberBins = 2;
-        _deltaIds = new uint256[](_numberBins);
-        _deltaIds[0] = ID_ONE;
-        _deltaIds[1] = ID_ONE + 1;
+        _ids = new uint256[](_numberBins);
+        _ids[0] = ID_ONE;
+        _ids[1] = ID_ONE + 1;
         _distributionX = new uint256[](_numberBins);
         _distributionY = new uint256[](_numberBins);
         _distributionX[0] = Constants.PRECISION / 2;
         _distributionX[1] = Constants.PRECISION / 2 + 1;
         vm.expectRevert(LBPair__DistributionsOverflow.selector);
-        pair.mint(_deltaIds, _distributionX, _distributionY, DEV);
+        pair.mint(_ids, _distributionX, _distributionY, DEV);
 
+        _ids[0] = ID_ONE - 1;
+        _ids[1] = ID_ONE;
         _distributionX[0] = 0;
         _distributionX[1] = 0;
         _distributionY[0] = Constants.PRECISION / 2;
         _distributionY[1] = Constants.PRECISION / 2 + 1;
         vm.expectRevert(LBPair__DistributionsOverflow.selector);
-        pair.mint(_deltaIds, _distributionX, _distributionY, DEV);
+        pair.mint(_ids, _distributionX, _distributionY, DEV);
     }
 
     function testInsufficientLiquidityBurnedReverts() public {
         uint256 _numberBins = 2;
-        uint256[] memory _deltaIds;
+        uint256[] memory _ids;
         uint256[] memory _amounts;
-        _deltaIds = new uint256[](_numberBins);
+        _ids = new uint256[](_numberBins);
         _amounts = new uint256[](_numberBins);
-        _deltaIds[0] = ID_ONE;
-        _deltaIds[1] = ID_ONE + 1;
+        _ids[0] = ID_ONE;
+        _ids[1] = ID_ONE + 1;
         _amounts[0] = 0;
         _amounts[1] = 0;
-        vm.expectRevert(abi.encodeWithSelector(LBPair__InsufficientLiquidityBurned.selector, _deltaIds[0]));
-        pair.burn(_deltaIds, _amounts, DEV);
+        vm.expectRevert(abi.encodeWithSelector(LBPair__InsufficientLiquidityBurned.selector, _ids[0]));
+        pair.burn(_ids, _amounts, DEV);
     }
 
     function testCollectingFeesOnlyFeeRecipient() public {

--- a/test/LBRouter.t.sol
+++ b/test/LBRouter.t.sol
@@ -402,7 +402,7 @@ contract LiquidityBinRouterTest is TestHelper {
         (uint256 amountIn2, ) = router.getSwapIn(pair, _amountYIn - 100, true);
     }
 
-    function testSweepLBToken() public {
+    function testSendTokensToContractThatDoesNotSupportLBToken() public {
         uint256 amountIn = 1e18;
 
         pair = createLBPairDefaultFees(token6D, token18D);
@@ -410,12 +410,8 @@ contract LiquidityBinRouterTest is TestHelper {
 
         uint256[] memory amounts = new uint256[](5);
         for (uint256 i; i < 5; i++) {
-            assertEq(pair.userPositionAtIndex(DEV, i), _ids[i]);
             amounts[i] = pair.balanceOf(DEV, _ids[i]);
         }
-        assertEq(pair.userPositionNumber(DEV), 5);
-
-        assertEq(pair.balanceOf(DEV, ID_ONE - 1), amountIn / 3);
 
         vm.expectRevert(abi.encodeWithSelector(LBToken__NotSupported.selector));
         pair.safeBatchTransferFrom(DEV, address(router), _ids, amounts);

--- a/test/LBToken.t.sol
+++ b/test/LBToken.t.sol
@@ -34,10 +34,8 @@ contract LiquidityBinTokenTest is TestHelper {
 
         uint256[] memory amounts = new uint256[](5);
         for (uint256 i; i < 5; i++) {
-            assertEq(pair.userPositionAtIndex(DEV, i), _ids[i]);
             amounts[i] = pair.balanceOf(DEV, _ids[i]);
         }
-        assertEq(pair.userPositionNumber(DEV), 5);
 
         assertEq(pair.balanceOf(DEV, ID_ONE - 1), amountIn / 3);
         vm.expectEmit(true, true, true, true);
@@ -67,10 +65,8 @@ contract LiquidityBinTokenTest is TestHelper {
 
         uint256[] memory amounts = new uint256[](5);
         for (uint256 i; i < 5; i++) {
-            assertEq(pair.userPositionAtIndex(DEV, i), _ids[i]);
             amounts[i] = pair.balanceOf(DEV, _ids[i]);
         }
-        assertEq(pair.userPositionNumber(DEV), 5);
 
         assertEq(pair.balanceOf(DEV, ID_ONE - 1), amountIn / 3);
         vm.expectEmit(true, true, true, true);
@@ -99,7 +95,6 @@ contract LiquidityBinTokenTest is TestHelper {
 
         uint256[] memory amounts = new uint256[](5);
         for (uint256 i; i < 5; i++) {
-            assertEq(pair.userPositionAtIndex(DEV, i), _ids[i]);
             amounts[i] = pair.balanceOf(DEV, _ids[i]);
         }
 
@@ -114,7 +109,6 @@ contract LiquidityBinTokenTest is TestHelper {
 
         uint256[] memory amounts = new uint256[](5);
         for (uint256 i; i < 5; i++) {
-            assertEq(pair.userPositionAtIndex(DEV, i), _ids[i]);
             amounts[i] = pair.balanceOf(DEV, _ids[i]);
         }
 
@@ -130,7 +124,6 @@ contract LiquidityBinTokenTest is TestHelper {
 
         uint256[] memory amounts = new uint256[](binAmount);
         for (uint256 i; i < binAmount; i++) {
-            assertEq(pair.userPositionAtIndex(DEV, i), _ids[i]);
             amounts[i] = pair.balanceOf(DEV, _ids[i]);
         }
 
@@ -163,7 +156,6 @@ contract LiquidityBinTokenTest is TestHelper {
 
         uint256[] memory amounts = new uint256[](binAmount);
         for (uint256 i; i < binAmount; i++) {
-            assertEq(pair.userPositionAtIndex(DEV, i), _ids[i]);
             amounts[i] = pair.balanceOf(DEV, _ids[i]);
         }
 
@@ -195,7 +187,6 @@ contract LiquidityBinTokenTest is TestHelper {
 
         uint256[] memory amounts = new uint256[](binAmount - 1);
         for (uint256 i; i < binAmount - 1; i++) {
-            assertEq(pair.userPositionAtIndex(DEV, i), _ids[i]);
             amounts[i] = pair.balanceOf(DEV, _ids[i]);
         }
 
@@ -244,7 +235,6 @@ contract LiquidityBinTokenTest is TestHelper {
         (_ids, , , ) = addLiquidity(amountIn, _startId, binAmount, _gap);
         uint256[] memory amounts = new uint256[](binAmount);
         for (uint256 i; i < binAmount; i++) {
-            assertEq(pair.userPositionAtIndex(DEV, i), _ids[i]);
             amounts[i] = pair.balanceOf(DEV, _ids[i]);
         }
         batchBalances = pair.balanceOfBatch(accounts, _ids);


### PR DESCRIPTION
This PR aims to reduce the contract size by:
- dropping the user sets. This will be done by external toolings (subgraph, API...)
- optimize some parts of the contract
- a more EIP-compliant flash loan