### PR TITLE
More binsteps

### DIFF
--- a/script/config/bips-config.sol
+++ b/script/config/bips-config.sol
@@ -4,7 +4,7 @@ pragma solidity 0.8.10;
 
 library BipsConfig {
     struct FactoryPreset {
-        uint8 binStep;
+        uint16 binStep;
         uint16 baseFactor;
         uint16 filterPeriod;
         uint16 decayPeriod;
@@ -13,6 +13,7 @@ library BipsConfig {
         uint16 protocolShare;
         uint24 maxVolatilityAccumulated;
         uint16 sampleLifetime;
+        bool isOpen;
     }
 
     function getPreset(uint256 _bp) internal pure returns (FactoryPreset memory preset) {
@@ -26,6 +27,7 @@ library BipsConfig {
             preset.protocolShare = 0;
             preset.maxVolatilityAccumulated = 100_000;
             preset.sampleLifetime = 120;
+            preset.isOpen = false;
         } else if (_bp == 2) {
             preset.binStep = 2;
             preset.baseFactor = 15_000;
@@ -36,6 +38,7 @@ library BipsConfig {
             preset.protocolShare = 0;
             preset.maxVolatilityAccumulated = 250_000;
             preset.sampleLifetime = 120;
+            preset.isOpen = false;
         } else if (_bp == 5) {
             preset.binStep = 5;
             preset.baseFactor = 8_000;
@@ -46,6 +49,7 @@ library BipsConfig {
             preset.protocolShare = 0;
             preset.maxVolatilityAccumulated = 300_000;
             preset.sampleLifetime = 120;
+            preset.isOpen = false;
         } else if (_bp == 10) {
             preset.binStep = 10;
             preset.baseFactor = 10_000;
@@ -56,6 +60,7 @@ library BipsConfig {
             preset.protocolShare = 0;
             preset.maxVolatilityAccumulated = 350_000;
             preset.sampleLifetime = 120;
+            preset.isOpen = false;
         } else if (_bp == 15) {
             preset.binStep = 15;
             preset.baseFactor = 10_000;
@@ -66,6 +71,7 @@ library BipsConfig {
             preset.protocolShare = 0;
             preset.maxVolatilityAccumulated = 350_000;
             preset.sampleLifetime = 120;
+            preset.isOpen = false;
         } else if (_bp == 20) {
             preset.binStep = 20;
             preset.baseFactor = 10_000;
@@ -76,6 +82,7 @@ library BipsConfig {
             preset.protocolShare = 0;
             preset.maxVolatilityAccumulated = 350_000;
             preset.sampleLifetime = 120;
+            preset.isOpen = false;
         } else if (_bp == 25) {
             preset.binStep = 25;
             preset.baseFactor = 10_000;
@@ -86,6 +93,7 @@ library BipsConfig {
             preset.protocolShare = 0;
             preset.maxVolatilityAccumulated = 350_000;
             preset.sampleLifetime = 120;
+            preset.isOpen = false;
         }
     }
 

--- a/script/deploy-core.s.sol
+++ b/script/deploy-core.s.sol
@@ -89,7 +89,8 @@ contract CoreDeployer is Script {
                     preset.reductionFactor,
                     preset.variableFeeControl,
                     preset.protocolShare,
-                    preset.maxVolatilityAccumulated
+                    preset.maxVolatilityAccumulated,
+                    preset.isOpen
                 );
             }
 

--- a/src/LBFactory.sol
+++ b/src/LBFactory.sol
@@ -289,7 +289,7 @@ contract LBFactory is PendingOwnable, ILBFactory {
      * @param tokenX The address of the first token
      * @param tokenY The address of the second token
      * @param activeId The active id of the pair
-     * @param binStep The bin step in basis point, used to calculate log(1 + binStep / 100_000)
+     * @param binStep The bin step in basis point, used to calculate log(1 + binStep / 10_000)
      * @return pair The address of the newly created LBPair
      */
     function createLBPair(IERC20 tokenX, IERC20 tokenY, uint24 activeId, uint16 binStep)

--- a/src/LBFactory.sol
+++ b/src/LBFactory.sol
@@ -3,6 +3,7 @@
 pragma solidity 0.8.10;
 
 import {EnumerableSet} from "openzeppelin/utils/structs/EnumerableSet.sol";
+import {EnumerableMap} from "openzeppelin/utils/structs/EnumerableMap.sol";
 import {IERC20} from "openzeppelin/token/ERC20/IERC20.sol";
 
 import {BinHelper, PairParameterHelper} from "./libraries/BinHelper.sol";
@@ -21,18 +22,22 @@ import {ILBPair} from "./interfaces/ILBPair.sol";
  * @author Trader Joe
  * @notice Contract used to deploy and register new LBPairs.
  * Enables setting fee parameters, flashloan fees and LBPair implementation.
- * Unless the `_isPresetOpen` is `true`, only the owner of the factory can create pairs.
+ * Unless the `isOpen` is `true`, only the owner of the factory can create pairs.
  */
 contract LBFactory is PendingOwnable, ILBFactory {
     using SafeCast for uint256;
     using Encoded for bytes32;
     using PairParameterHelper for bytes32;
     using EnumerableSet for EnumerableSet.AddressSet;
+    using EnumerableSet for EnumerableSet.UintSet;
+    using EnumerableMap for EnumerableMap.UintToUintMap;
 
-    uint256 private constant _MIN_BIN_STEP = 1; // 0.01%
-    uint256 private constant _MAX_BIN_STEP = 200; // 1%, can't be greater than 247 for indexing reasons
+    uint256 private constant _OFFSET_IS_PRESET_OPEN = 255;
+
+    uint256 private constant _MIN_BIN_STEP = 1; // 0.001%
 
     uint256 private constant _MAX_FLASHLOAN_FEE = 0.1e18; // 10%
+
     address private _feeRecipient;
     uint256 private _flashLoanFee;
 
@@ -40,35 +45,20 @@ contract LBFactory is PendingOwnable, ILBFactory {
 
     ILBPair[] private _allLBPairs;
 
-    uint256 private constant _TRUE = 1;
-    uint256 private constant _FALSE = 0;
-
     /**
      * @dev Mapping from a (tokenA, tokenB, binStep) to a LBPair. The tokens are ordered to save gas, but they can be
      * in the reverse order in the actual pair. Always query one of the 2 tokens of the pair to assert the order of the 2 tokens
      */
     mapping(IERC20 => mapping(IERC20 => mapping(uint256 => LBPairInformation))) private _lbPairsInfo;
 
-    /**
-     * @dev Whether a preset was set or not, if the bit at `index` is 1, it means that the binStep `index` was set
-     * The max binStep set is 247. We use this method instead of an array to keep it ordered and to reduce gas
-     */
-    bytes32 private _availablePresets;
-
-    /**
-     * @dev Whether a preset is open to anyone to create pairs, if the bit at `index` is 1, it means that the binStep `index` was set
-     */
-    bytes32 private _openPresets;
-
-    mapping(uint256 => bytes32) private _presets;
-
+    EnumerableMap.UintToUintMap private _presets;
     EnumerableSet.AddressSet private _quoteAssetWhitelist;
 
     /**
      * @dev Whether a LBPair was created with a bin step, if the bit at `index` is 1, it means that the LBPair with binStep `index` exists
      * The max binStep set is 247. We use this method instead of an array to keep it ordered and to reduce gas
      */
-    mapping(IERC20 => mapping(IERC20 => bytes32)) private _availableLBPairBinSteps;
+    mapping(IERC20 => mapping(IERC20 => EnumerableSet.UintSet)) private _availableLBPairBinSteps; // todo change
 
     /**
      * @notice Constructor
@@ -89,23 +79,15 @@ contract LBFactory is PendingOwnable, ILBFactory {
      * @notice Get the minimum bin step a pair can have
      * @return minBinStep
      */
-    function getMinBinStep() external pure returns (uint256 minBinStep) {
+    function getMinBinStep() external pure override returns (uint256 minBinStep) {
         return _MIN_BIN_STEP;
-    }
-
-    /**
-     * @notice Get the maximum bin step a pair can have
-     * @return maxBinStep
-     */
-    function getMaxBinStep() external pure returns (uint256 maxBinStep) {
-        return _MAX_BIN_STEP;
     }
 
     /**
      * @notice Get the protocol fee recipient
      * @return feeRecipient
      */
-    function getFeeRecipient() external view returns (address feeRecipient) {
+    function getFeeRecipient() external view override returns (address feeRecipient) {
         return _feeRecipient;
     }
 
@@ -113,7 +95,7 @@ contract LBFactory is PendingOwnable, ILBFactory {
      * @notice Get the maximum fee percentage for flashLoans
      * @return maxFee
      */
-    function getMaxFlashLoanFee() external pure returns (uint256 maxFee) {
+    function getMaxFlashLoanFee() external pure override returns (uint256 maxFee) {
         return _MAX_FLASHLOAN_FEE;
     }
 
@@ -121,7 +103,7 @@ contract LBFactory is PendingOwnable, ILBFactory {
      * @notice Get the fee for flash loans
      * @return flashloanFee
      */
-    function getFlashLoanFee() external view returns (uint256 flashloanFee) {
+    function getFlashLoanFee() external view override returns (uint256 flashloanFee) {
         return _flashLoanFee;
     }
 
@@ -129,7 +111,7 @@ contract LBFactory is PendingOwnable, ILBFactory {
      * @notice Get the address of the LBPair implementation
      * @return lbPairImplementation
      */
-    function getLBPairImplementation() external view returns (address lbPairImplementation) {
+    function getLBPairImplementation() external view override returns (address lbPairImplementation) {
         return _lbPairImplementation;
     }
 
@@ -146,7 +128,7 @@ contract LBFactory is PendingOwnable, ILBFactory {
      * @param index The index
      * @return lbPair The address of the LBPair at index `index`
      */
-    function getLBPairAtIndex(uint256 index) external view returns (ILBPair lbPair) {
+    function getLBPairAtIndex(uint256 index) external view override returns (ILBPair lbPair) {
         return _allLBPairs[index];
     }
 
@@ -187,6 +169,7 @@ contract LBFactory is PendingOwnable, ILBFactory {
     function getLBPairInformation(IERC20 tokenA, IERC20 tokenB, uint256 binStep)
         external
         view
+        override
         returns (LBPairInformation memory lbPairInformation)
     {
         return _getLBPairInformation(tokenA, tokenB, binStep);
@@ -194,6 +177,7 @@ contract LBFactory is PendingOwnable, ILBFactory {
 
     /**
      * @notice View function to return the different parameters of the preset
+     * Will revert if the preset doesn't exist
      * @param binStep The bin step of the preset
      * @return baseFactor The base factor
      * @return filterPeriod The filter period of the preset
@@ -202,6 +186,7 @@ contract LBFactory is PendingOwnable, ILBFactory {
      * @return variableFeeControl The variable fee control of the preset
      * @return protocolShare The protocol share of the preset
      * @return maxVolatilityAccumulator The max volatility accumulator of the preset
+     * @return isOpen Whether the preset is open or not
      */
     function getPreset(uint256 binStep)
         external
@@ -214,11 +199,13 @@ contract LBFactory is PendingOwnable, ILBFactory {
             uint256 reductionFactor,
             uint256 variableFeeControl,
             uint256 protocolShare,
-            uint256 maxVolatilityAccumulator
+            uint256 maxVolatilityAccumulator,
+            bool isOpen
         )
     {
-        bytes32 preset = _presets[binStep];
-        if (preset == bytes32(0)) revert LBFactory__BinStepHasNoPreset(binStep);
+        if (!_presets.contains(binStep)) revert LBFactory__BinStepHasNoPreset(binStep);
+
+        bytes32 preset = bytes32(_presets.get(binStep));
 
         baseFactor = preset.getBaseFactor();
         filterPeriod = preset.getFilterPeriod();
@@ -227,17 +214,8 @@ contract LBFactory is PendingOwnable, ILBFactory {
         variableFeeControl = preset.getVariableFeeControl();
         protocolShare = preset.getProtocolShare();
         maxVolatilityAccumulator = preset.getMaxVolatilityAccumulator();
-    }
 
-    /**
-     * @notice View function to return whether a preset is available to anyone for pair creation (true) or not (false)
-     * @param binStep The bin step of the preset
-     * @return isAvailable Whether the preset is available or not
-     */
-    function isPresetOpen(uint8 binStep) external view returns (bool isAvailable) {
-        bytes32 openPresets = _openPresets;
-
-        return _isPresetOpen(openPresets, binStep);
+        isOpen = preset.decodeBool(_OFFSET_IS_PRESET_OPEN);
     }
 
     /**
@@ -245,22 +223,7 @@ contract LBFactory is PendingOwnable, ILBFactory {
      * @return binStepWithPreset The list of binStep
      */
     function getAllBinSteps() external view override returns (uint256[] memory binStepWithPreset) {
-        unchecked {
-            bytes32 avPresets = _availablePresets;
-            uint256 nbPresets = avPresets.decodeUint8(248);
-
-            if (nbPresets > 0) {
-                binStepWithPreset = new uint256[](nbPresets);
-
-                uint256 index;
-                for (uint256 i = _MIN_BIN_STEP; i <= _MAX_BIN_STEP; ++i) {
-                    if (avPresets.decodeUint1(i) == _TRUE) {
-                        binStepWithPreset[index] = i;
-                        if (++index == nbPresets) break;
-                    }
-                }
-            }
-        }
+        return _presets.keys();
     }
 
     /**
@@ -278,25 +241,24 @@ contract LBFactory is PendingOwnable, ILBFactory {
         unchecked {
             (IERC20 tokenA, IERC20 tokenB) = _sortTokens(tokenX, tokenY);
 
-            bytes32 avLBPairBinSteps = _availableLBPairBinSteps[tokenA][tokenB];
-            uint256 nbAvailable = avLBPairBinSteps.decodeUint8(248);
+            EnumerableSet.UintSet storage addressSet = _availableLBPairBinSteps[tokenA][tokenB];
 
-            if (nbAvailable > 0) {
-                lbPairsAvailable = new LBPairInformation[](nbAvailable);
+            uint256 length = addressSet.length();
 
-                uint256 index;
-                for (uint256 i = _MIN_BIN_STEP; i <= _MAX_BIN_STEP; ++i) {
-                    if (avLBPairBinSteps.decodeUint1(i) == _TRUE) {
-                        LBPairInformation memory pairInformation = _lbPairsInfo[tokenA][tokenB][i];
+            if (length > 0) {
+                lbPairsAvailable = new LBPairInformation[](length);
 
-                        lbPairsAvailable[index] = LBPairInformation({
-                            binStep: i.safe8(),
-                            LBPair: pairInformation.LBPair,
-                            createdByOwner: pairInformation.createdByOwner,
-                            ignoredForRouting: pairInformation.ignoredForRouting
-                        });
-                        if (++index == nbAvailable) break;
-                    }
+                mapping(uint256 => LBPairInformation) storage lbPairsInfo = _lbPairsInfo[tokenA][tokenB];
+
+                for (uint256 i = 0; i < length; ++i) {
+                    uint16 binStep = addressSet.at(i).safe16();
+
+                    lbPairsAvailable[i] = LBPairInformation({
+                        binStep: binStep,
+                        LBPair: lbPairsInfo[binStep].LBPair,
+                        createdByOwner: lbPairsInfo[binStep].createdByOwner,
+                        ignoredForRouting: lbPairsInfo[binStep].ignoredForRouting
+                    });
                 }
             }
         }
@@ -327,15 +289,19 @@ contract LBFactory is PendingOwnable, ILBFactory {
      * @param tokenX The address of the first token
      * @param tokenY The address of the second token
      * @param activeId The active id of the pair
-     * @param binStep The bin step in basis point, used to calculate log(1 + binStep)
+     * @param binStep The bin step in basis point, used to calculate log(1 + binStep / 100_000)
      * @return pair The address of the newly created LBPair
      */
-    function createLBPair(IERC20 tokenX, IERC20 tokenY, uint24 activeId, uint8 binStep)
+    function createLBPair(IERC20 tokenX, IERC20 tokenY, uint24 activeId, uint16 binStep)
         external
         override
         returns (ILBPair pair)
     {
-        if (!_isPresetOpen(_openPresets, binStep) && msg.sender != owner()) {
+        if (!_presets.contains(binStep)) revert LBFactory__BinStepHasNoPreset(binStep);
+
+        bytes32 preset = bytes32(_presets.get(binStep));
+
+        if (!_isPresetOpen(preset) && msg.sender != owner()) {
             revert LBFactory__FunctionIsLockedForUsers(msg.sender, binStep);
         }
 
@@ -358,30 +324,24 @@ contract LBFactory is PendingOwnable, ILBFactory {
             revert LBFactory__LBPairAlreadyExists(tokenX, tokenY, binStep);
         }
 
-        // We remove the bits that are not part of the feeParameters
-        {
-            bytes32 salt = keccak256(abi.encode(tokenA, tokenB, binStep));
-            pair = ILBPair(
-                ImmutableClone.cloneDeterministic(implementation, abi.encodePacked(tokenX, tokenY, binStep), salt)
-            );
-        }
+        pair = ILBPair(
+            ImmutableClone.cloneDeterministic(
+                implementation,
+                abi.encodePacked(tokenX, tokenY, binStep),
+                keccak256(abi.encode(tokenA, tokenB, binStep))
+            )
+        );
 
-        {
-            bytes32 preset = _presets[binStep];
-
-            if (preset == bytes32(0)) revert LBFactory__BinStepHasNoPreset(binStep);
-
-            pair.initialize(
-                preset.getBaseFactor(),
-                preset.getFilterPeriod(),
-                preset.getDecayPeriod(),
-                preset.getReductionFactor(),
-                preset.getVariableFeeControl(),
-                preset.getProtocolShare(),
-                preset.getMaxVolatilityAccumulator(),
-                activeId
-            );
-        }
+        pair.initialize(
+            preset.getBaseFactor(),
+            preset.getFilterPeriod(),
+            preset.getDecayPeriod(),
+            preset.getReductionFactor(),
+            preset.getVariableFeeControl(),
+            preset.getProtocolShare(),
+            preset.getMaxVolatilityAccumulator(),
+            activeId
+        );
 
         _lbPairsInfo[tokenA][tokenB][binStep] = LBPairInformation({
             binStep: binStep,
@@ -391,18 +351,7 @@ contract LBFactory is PendingOwnable, ILBFactory {
         });
 
         _allLBPairs.push(pair);
-
-        {
-            bytes32 avLBPairBinSteps = _availableLBPairBinSteps[tokenA][tokenB];
-            // We add a 1 at bit `binStep` as this binStep is now set
-            avLBPairBinSteps = avLBPairBinSteps.set(_TRUE, Encoded.MASK_UINT1, binStep);
-
-            // Increase the number of lb pairs by 1
-            avLBPairBinSteps = bytes32(uint256(avLBPairBinSteps) + (1 << 248));
-
-            // Save the changes
-            _availableLBPairBinSteps[tokenA][tokenB] = avLBPairBinSteps;
-        }
+        _availableLBPairBinSteps[tokenA][tokenB].add(binStep);
 
         emit LBPairCreated(tokenX, tokenY, binStep, pair, _allLBPairs.length - 1);
     }
@@ -414,15 +363,13 @@ contract LBFactory is PendingOwnable, ILBFactory {
      * @param binStep The bin step in basis point of the pair
      * @param ignored Whether to ignore (true) or not (false) the pair for routing
      */
-    function setLBPairIgnored(IERC20 tokenX, IERC20 tokenY, uint256 binStep, bool ignored)
-        external
-        override
-        onlyOwner
-    {
+    function setLBPairIgnored(IERC20 tokenX, IERC20 tokenY, uint16 binStep, bool ignored) external override onlyOwner {
         (IERC20 tokenA, IERC20 tokenB) = _sortTokens(tokenX, tokenY);
 
         LBPairInformation memory pairInformation = _lbPairsInfo[tokenA][tokenB][binStep];
-        if (address(pairInformation.LBPair) == address(0)) revert LBFactory__AddressZero();
+        if (address(pairInformation.LBPair) == address(0)) {
+            revert LBFactory__LBPairDoesNotExist(tokenX, tokenY, binStep);
+        }
 
         if (pairInformation.ignoredForRouting == ignored) revert LBFactory__LBPairIgnoredIsAlreadyInTheSameState();
 
@@ -433,7 +380,7 @@ contract LBFactory is PendingOwnable, ILBFactory {
 
     /**
      * @notice Sets the preset parameters of a bin step
-     * @param binStep The bin step in basis point, used to calculate log(1 + binStep)
+     * @param binStep The bin step in basis point, used to calculate the price
      * @param baseFactor The base factor, used to calculate the base fee, baseFee = baseFactor * binStep
      * @param filterPeriod The period where the accumulator value is untouched, prevent spam
      * @param decayPeriod The period where the accumulator value is halved
@@ -443,18 +390,19 @@ contract LBFactory is PendingOwnable, ILBFactory {
      * @param maxVolatilityAccumulator The max value of the volatility accumulator
      */
     function setPreset(
-        uint8 binStep,
+        uint16 binStep,
         uint16 baseFactor,
         uint16 filterPeriod,
         uint16 decayPeriod,
         uint16 reductionFactor,
         uint24 variableFeeControl,
         uint16 protocolShare,
-        uint24 maxVolatilityAccumulator
+        uint24 maxVolatilityAccumulator,
+        bool isOpen
     ) external override onlyOwner {
-        bytes32 preset;
+        if (binStep < _MIN_BIN_STEP) revert LBFactory__BinStepTooLow(binStep);
 
-        _presets[binStep] = preset.setStaticFeeParameters(
+        bytes32 preset = bytes32(0).setStaticFeeParameters(
             baseFactor,
             filterPeriod,
             decayPeriod,
@@ -464,17 +412,11 @@ contract LBFactory is PendingOwnable, ILBFactory {
             maxVolatilityAccumulator
         );
 
-        bytes32 avPresets = _availablePresets;
-        if (avPresets.decodeUint1(binStep) == 0) {
-            // We add a 1 at bit `binStep` as this binStep is now set
-            avPresets = avPresets.set(_TRUE, Encoded.MASK_UINT1, binStep);
-
-            // Increase the number of preset by 1
-            avPresets = bytes32(uint256(avPresets) + (1 << 248));
-
-            // Save the changes
-            _availablePresets = avPresets;
+        if (isOpen) {
+            preset = preset.setBool(true, _OFFSET_IS_PRESET_OPEN);
         }
+
+        _presets.set(binStep, uint256(preset));
 
         emit PresetSet(
             binStep,
@@ -486,49 +428,35 @@ contract LBFactory is PendingOwnable, ILBFactory {
             protocolShare,
             maxVolatilityAccumulator
             );
+
+        emit PresetOpenStateChanged(binStep, isOpen);
     }
 
     /**
-     * @notice Sets the open state of a preset. If true, anyone can create a pair with this preset,
-     * if false, it is restricted to the owner of the factory
-     * @param binStep The bin step to open or close
-     * @param isOpen Whether the preset will be open or not
+     * @notice Sets if the preset is open or not to be used by users
+     * @param binStep The bin step in basis point, used to calculate the price
+     * @param isOpen Whether the preset is open or not
      */
-    function setOpenPreset(uint8 binStep, bool isOpen) external onlyOwner {
-        bytes32 openPresets = _openPresets;
-        bool isPresetOpenCurrent = _isPresetOpen(openPresets, binStep);
+    function setPresetOpenState(uint16 binStep, bool isOpen) external override onlyOwner {
+        if (!_presets.contains(binStep)) revert LBFactory__BinStepHasNoPreset(binStep);
 
-        if (isOpen) {
-            if (isPresetOpenCurrent) revert LBFactory__SamePresetOpenState();
+        bytes32 preset = bytes32(_presets.get(binStep));
 
-            // We add a 1 at bit `binStep` as this binStep is now open
-            _openPresets = _openPresets.set(_TRUE, Encoded.MASK_UINT1, binStep);
-        } else {
-            if (!isPresetOpenCurrent) revert LBFactory__SamePresetOpenState();
-
-            // We remove a 1 at bit `binStep` as this binStep is now closed
-            _openPresets = _openPresets.set(_FALSE, Encoded.MASK_UINT1, binStep);
+        if (preset.decodeBool(_OFFSET_IS_PRESET_OPEN) == isOpen) {
+            revert LBFactory__PresetOpenStateIsAlreadyInTheSameState();
         }
 
-        emit OpenPresetChanged(binStep, isOpen);
+        _presets.set(binStep, uint256(preset.setBool(isOpen, _OFFSET_IS_PRESET_OPEN)));
+
+        emit PresetOpenStateChanged(binStep, isOpen);
     }
 
     /**
      * @notice Remove the preset linked to a binStep
      * @param binStep The bin step to remove
      */
-    function removePreset(uint8 binStep) external override onlyOwner {
-        if (_presets[binStep] == bytes32(0)) revert LBFactory__BinStepHasNoPreset(binStep);
-
-        // Set the bit `binStep` to 0
-        bytes32 avPresets = _availablePresets;
-
-        avPresets = avPresets.set(_FALSE, Encoded.MASK_UINT1, binStep);
-        avPresets = bytes32(uint256(avPresets) - (1 << 248));
-
-        // Save the changes
-        _availablePresets = avPresets;
-        delete _presets[binStep];
+    function removePreset(uint16 binStep) external override onlyOwner {
+        if (!_presets.remove(binStep)) revert LBFactory__BinStepHasNoPreset(binStep);
 
         emit PresetRemoved(binStep);
     }
@@ -537,7 +465,7 @@ contract LBFactory is PendingOwnable, ILBFactory {
      * @notice Function to set the fee parameter of a LBPair
      * @param tokenX The address of the first token
      * @param tokenY The address of the second token
-     * @param binStep The bin step in basis point, used to calculate log(1 + binStep)
+     * @param binStep The bin step in basis point, used to calculate the price
      * @param baseFactor The base factor, used to calculate the base fee, baseFee = baseFactor * binStep
      * @param filterPeriod The period where the accumulator value is untouched, prevent spam
      * @param decayPeriod The period where the accumulator value is halved
@@ -549,7 +477,7 @@ contract LBFactory is PendingOwnable, ILBFactory {
     function setFeesParametersOnPair(
         IERC20 tokenX,
         IERC20 tokenY,
-        uint8 binStep,
+        uint16 binStep,
         uint16 baseFactor,
         uint16 filterPeriod,
         uint16 decayPeriod,
@@ -617,8 +545,8 @@ contract LBFactory is PendingOwnable, ILBFactory {
         emit QuoteAssetRemoved(quoteAsset);
     }
 
-    function _isPresetOpen(bytes32 openPresets, uint8 binStep) internal pure returns (bool) {
-        return openPresets.decodeUint1(binStep) == 1;
+    function _isPresetOpen(bytes32 preset) internal pure returns (bool) {
+        return preset.decodeBool(_OFFSET_IS_PRESET_OPEN);
     }
 
     /**

--- a/src/LBFactory.sol
+++ b/src/LBFactory.sol
@@ -58,7 +58,7 @@ contract LBFactory is PendingOwnable, ILBFactory {
      * @dev Whether a LBPair was created with a bin step, if the bit at `index` is 1, it means that the LBPair with binStep `index` exists
      * The max binStep set is 247. We use this method instead of an array to keep it ordered and to reduce gas
      */
-    mapping(IERC20 => mapping(IERC20 => EnumerableSet.UintSet)) private _availableLBPairBinSteps; // todo change
+    mapping(IERC20 => mapping(IERC20 => EnumerableSet.UintSet)) private _availableLBPairBinSteps;
 
     /**
      * @notice Constructor

--- a/src/LBPair.sol
+++ b/src/LBPair.sol
@@ -146,7 +146,7 @@ contract LBPair is LBToken, ReentrancyGuard, Clone, ILBPair {
      * @dev The bin step is the increase in price between two consecutive bins, in basis points.
      * For example, a bin step of 1 means that the price of the next bin is 0.01% higher than the price of the previous bin.
      * The maximum bin step is 200, which means that the price of the next bin is 1% higher than the price of the previous bin.
-     * @return binStep The bin step of the Liquidity Book Pair, in 100_000th
+     * @return binStep The bin step of the Liquidity Book Pair, in 10_000th
      */
     function getBinStep() external pure override returns (uint16) {
         return _binStep();

--- a/src/LBPair.sol
+++ b/src/LBPair.sol
@@ -143,12 +143,12 @@ contract LBPair is LBToken, ReentrancyGuard, Clone, ILBPair {
 
     /**
      * @notice Returns the bin step of the Liquidity Book Pair
-     * @dev The bin step is the increase in price between two consecutive bins, in 20_000th.
-     * For example, a bin step of 1 means that the price of the next bin is 0.005% higher than the price of the previous bin.
+     * @dev The bin step is the increase in price between two consecutive bins, in basis points.
+     * For example, a bin step of 1 means that the price of the next bin is 0.01% higher than the price of the previous bin.
      * The maximum bin step is 200, which means that the price of the next bin is 1% higher than the price of the previous bin.
-     * @return binStep The bin step of the Liquidity Book Pair, in 20_000th
+     * @return binStep The bin step of the Liquidity Book Pair, in 100_000th
      */
-    function getBinStep() external pure override returns (uint8) {
+    function getBinStep() external pure override returns (uint16) {
         return _binStep();
     }
 
@@ -166,7 +166,7 @@ contract LBPair is LBToken, ReentrancyGuard, Clone, ILBPair {
      * @notice Returns the active id of the Liquidity Book Pair
      * @dev The active id is the id of the bin that is currently being used for swaps.
      * The price of the active bin is the price of the Liquidity Book Pair and can be calculated as follows:
-     * `price = (1 + binStep / 20_000) ^ (activeId - 2^23)`
+     * `price = (1 + binStep / 10_000) ^ (activeId - 2^23)`
      * @return activeId The active id of the Liquidity Book Pair
      */
     function getActiveId() external view override returns (uint24 activeId) {
@@ -370,7 +370,7 @@ contract LBPair is LBToken, ReentrancyGuard, Clone, ILBPair {
         amountOutLeft = amountOut;
 
         bytes32 parameters = _parameters;
-        uint8 binStep = _binStep();
+        uint16 binStep = _binStep();
 
         uint24 id = parameters.getActiveId();
 
@@ -431,7 +431,7 @@ contract LBPair is LBToken, ReentrancyGuard, Clone, ILBPair {
         bytes32 amountsInLeft = amountIn.encode(swapForY);
 
         bytes32 parameters = _parameters;
-        uint8 binStep = _binStep();
+        uint16 binStep = _binStep();
 
         uint24 id = parameters.getActiveId();
 
@@ -491,7 +491,7 @@ contract LBPair is LBToken, ReentrancyGuard, Clone, ILBPair {
         if (amountsLeft == 0) revert LBPair__InsufficientAmountIn();
 
         bytes32 parameters = _parameters;
-        uint8 binStep = _binStep();
+        uint16 binStep = _binStep();
 
         uint24 activeId = parameters.getActiveId();
 
@@ -830,11 +830,11 @@ contract LBPair is LBToken, ReentrancyGuard, Clone, ILBPair {
     }
 
     /**
-     * @dev Returns the bin step of the pool, in 20_000ths.
+     * @dev Returns the bin step of the pool, in basis points
      * @return The bin step of the pool
      */
-    function _binStep() internal pure returns (uint8) {
-        return _getArgUint8(40);
+    function _binStep() internal pure returns (uint16) {
+        return _getArgUint16(40);
     }
 
     /**
@@ -904,7 +904,7 @@ contract LBPair is LBToken, ReentrancyGuard, Clone, ILBPair {
         );
 
         {
-            uint8 binStep = _binStep();
+            uint16 binStep = _binStep();
             bytes32 maxParameters = parameters.setVolatilityAccumulator(maxVolatilityAccumulator);
             uint256 totalFee = maxParameters.getBaseFee(binStep) + maxParameters.getVariableFee(binStep);
             if (totalFee > _MAX_TOTAL_FEE) {
@@ -941,7 +941,7 @@ contract LBPair is LBToken, ReentrancyGuard, Clone, ILBPair {
         returns (uint256 shares, bytes32 amountsIn, bytes32 amountsInToBin)
     {
         bytes32 binReserves = _bins[id];
-        uint8 binStep = _binStep();
+        uint16 binStep = _binStep();
 
         uint256 price = id.getPriceFromId(binStep);
         uint256 supply = totalSupply(id);

--- a/src/LBQuoter.sol
+++ b/src/LBQuoter.sol
@@ -208,7 +208,7 @@ contract LBQuoter {
                             if (amountInLeft == 0 && swapAmountOut > quote.amounts[i + 1]) {
                                 quote.amounts[i + 1] = swapAmountOut;
                                 quote.pairs[i] = address(LBPairsAvailable[j].LBPair);
-                                quote.binSteps[i] = uint8(LBPairsAvailable[j].binStep);
+                                quote.binSteps[i] = uint16(LBPairsAvailable[j].binStep);
                                 quote.versions[i] = ILBRouter.Version.V2_1;
 
                                 // Getting current price
@@ -326,7 +326,7 @@ contract LBQuoter {
                             ) {
                                 quote.amounts[i - 1] = swapAmountIn;
                                 quote.pairs[i - 1] = address(LBPairsAvailable[j].LBPair);
-                                quote.binSteps[i - 1] = uint8(LBPairsAvailable[j].binStep);
+                                quote.binSteps[i - 1] = uint16(LBPairsAvailable[j].binStep);
                                 quote.versions[i - 1] = ILBRouter.Version.V2_1;
 
                                 // Getting current price
@@ -383,11 +383,11 @@ contract LBQuoter {
     {
         if (swapForY) {
             quote = uint128(
-                PriceHelper.getPriceFromId(activeId, uint8(binStep)).mulShiftRoundDown(amount, Constants.SCALE_OFFSET)
+                PriceHelper.getPriceFromId(activeId, uint16(binStep)).mulShiftRoundDown(amount, Constants.SCALE_OFFSET)
             );
         } else {
             quote = uint128(
-                amount.shiftDivRoundDown(Constants.SCALE_OFFSET, PriceHelper.getPriceFromId(activeId, uint8(binStep)))
+                amount.shiftDivRoundDown(Constants.SCALE_OFFSET, PriceHelper.getPriceFromId(activeId, uint16(binStep)))
             );
         }
     }

--- a/src/LBRouter.sol
+++ b/src/LBRouter.sol
@@ -194,7 +194,7 @@ contract LBRouter is ILBRouter {
      * @param binStep The bin step in basis point, used to calculate log(1 + binStep)
      * @return pair The address of the newly created LBPair
      */
-    function createLBPair(IERC20 tokenX, IERC20 tokenY, uint24 activeId, uint8 binStep)
+    function createLBPair(IERC20 tokenX, IERC20 tokenY, uint24 activeId, uint16 binStep)
         external
         override
         returns (ILBPair pair)
@@ -308,7 +308,7 @@ contract LBRouter is ILBRouter {
     function removeLiquidity(
         IERC20 tokenX,
         IERC20 tokenY,
-        uint8 binStep,
+        uint16 binStep,
         uint256 amountXMin,
         uint256 amountYMin,
         uint256[] memory ids,
@@ -344,7 +344,7 @@ contract LBRouter is ILBRouter {
      */
     function removeLiquidityNATIVE(
         IERC20 token,
-        uint8 binStep,
+        uint16 binStep,
         uint256 amountTokenMin,
         uint256 amountNATIVEMin,
         uint256[] memory ids,

--- a/src/interfaces/ILBPair.sol
+++ b/src/interfaces/ILBPair.sol
@@ -88,7 +88,7 @@ interface ILBPair is ILBToken {
 
     function getTokenY() external view returns (IERC20 tokenY);
 
-    function getBinStep() external view returns (uint8 binStep);
+    function getBinStep() external view returns (uint16 binStep);
 
     function getReserves() external view returns (uint128 reserveX, uint128 reserveY);
 

--- a/src/interfaces/ILBRouter.sol
+++ b/src/interfaces/ILBRouter.sol
@@ -126,7 +126,7 @@ interface ILBRouter {
         view
         returns (uint128 amountInLeft, uint128 amountOut, uint128 fee);
 
-    function createLBPair(IERC20 tokenX, IERC20 tokenY, uint24 activeId, uint8 binStep)
+    function createLBPair(IERC20 tokenX, IERC20 tokenY, uint24 activeId, uint16 binStep)
         external
         returns (ILBPair pair);
 
@@ -156,7 +156,7 @@ interface ILBRouter {
     function removeLiquidity(
         IERC20 tokenX,
         IERC20 tokenY,
-        uint8 binStep,
+        uint16 binStep,
         uint256 amountXMin,
         uint256 amountYMin,
         uint256[] memory ids,
@@ -167,7 +167,7 @@ interface ILBRouter {
 
     function removeLiquidityNATIVE(
         IERC20 token,
-        uint8 binStep,
+        uint16 binStep,
         uint256 amountTokenMin,
         uint256 amountNATIVEMin,
         uint256[] memory ids,

--- a/src/libraries/BinHelper.sol
+++ b/src/libraries/BinHelper.sol
@@ -163,7 +163,7 @@ library BinHelper {
     function getCompositionFees(
         bytes32 binReserves,
         bytes32 parameters,
-        uint8 binStep,
+        uint16 binStep,
         bytes32 amountsIn,
         uint256 totalSupply,
         uint256 shares
@@ -211,7 +211,7 @@ library BinHelper {
     function getAmounts(
         bytes32 binReserves,
         bytes32 parameters,
-        uint8 binStep,
+        uint16 binStep,
         bool swapForY, // swap `swapForY` and `activeId` to avoid stack too deep
         uint24 activeId,
         bytes32 amountsInLeft

--- a/src/libraries/Clone.sol
+++ b/src/libraries/Clone.sol
@@ -93,6 +93,19 @@ abstract contract Clone {
     }
 
     /**
+     * @dev Reads an immutable arg with type uint16
+     * @param argOffset The offset of the arg in the immutable args
+     * @return arg The immutable uint16 arg
+     */
+    function _getArgUint16(uint256 argOffset) internal pure returns (uint16 arg) {
+        uint256 offset = _getImmutableArgsOffset();
+        /// @solidity memory-safe-assembly
+        assembly {
+            arg := shr(0xf0, calldataload(add(offset, argOffset)))
+        }
+    }
+
+    /**
      * @dev Reads an immutable arg with type uint8
      * @param argOffset The offset of the arg in the immutable args
      * @return arg The immutable uint8 arg

--- a/src/libraries/Constants.sol
+++ b/src/libraries/Constants.sol
@@ -18,7 +18,6 @@ library Constants {
     uint256 internal constant MAX_PROTOCOL_SHARE = 2_500; // 25% of the fee
 
     uint256 internal constant BASIS_POINT_MAX = 10_000;
-    uint256 internal constant TWO_BASIS_POINT_MAX = 2 * BASIS_POINT_MAX;
 
     /// @dev The expected return after a successful flash loan
     bytes32 internal constant CALLBACK_SUCCESS = keccak256("LBPair.onFlashLoan");

--- a/src/libraries/FeeHelper.sol
+++ b/src/libraries/FeeHelper.sol
@@ -36,11 +36,11 @@ library FeeHelper {
 
     /**
      * @dev Calculates the fee amount from the amount with fees, rounding up
-     * @param amounWithFees The amount with fees
+     * @param amountWithFees The amount with fees
      * @param totalFee The total fee
      * @return feeAmount The fee amount
      */
-    function getFeeAmountFrom(uint128 amounWithFees, uint128 totalFee)
+    function getFeeAmountFrom(uint128 amountWithFees, uint128 totalFee)
         internal
         pure
         checkFeeOverflow(totalFee)
@@ -48,7 +48,7 @@ library FeeHelper {
     {
         unchecked {
             // Can't overflow, max(result) = (type(uint128).max * 0.1e18 + 1e18 - 1) / 1e18 < 2^128
-            return uint128((uint256(amounWithFees) * totalFee + Constants.PRECISION - 1) / Constants.PRECISION);
+            return uint128((uint256(amountWithFees) * totalFee + Constants.PRECISION - 1) / Constants.PRECISION);
         }
     }
 

--- a/src/libraries/PairParameterHelper.sol
+++ b/src/libraries/PairParameterHelper.sol
@@ -220,31 +220,31 @@ library PairParameterHelper {
     /**
      * @dev Calculates the base fee, with 18 decimals
      * @param params The encoded pair parameters
-     * @param binStep The bin step (in 20_000th)
+     * @param binStep The bin step (in basis points)
      * @return baseFee The base fee
      */
-    function getBaseFee(bytes32 params, uint8 binStep) internal pure returns (uint256) {
+    function getBaseFee(bytes32 params, uint16 binStep) internal pure returns (uint256) {
         unchecked {
-            // Base factor is in basis points, binStep is in 20_000th, so we multiply by 5e9
-            return uint256(getBaseFactor(params)) * binStep * 5e9;
+            // Base factor is in basis points, binStep is in basis points, so we multiply by 1e10
+            return uint256(getBaseFactor(params)) * binStep * 1e10;
         }
     }
 
     /**
      * @dev Calculates the variable fee
      * @param params The encoded pair parameters
-     * @param binStep The bin step (in 20_000th)
+     * @param binStep The bin step (in basis points)
      * @return variableFee The variable fee
      */
-    function getVariableFee(bytes32 params, uint8 binStep) internal pure returns (uint256 variableFee) {
+    function getVariableFee(bytes32 params, uint16 binStep) internal pure returns (uint256 variableFee) {
         uint256 variableFeeControl = getVariableFeeControl(params);
 
         if (variableFeeControl != 0) {
             unchecked {
-                // The volatility accumulator is in basis points, binStep is in 20_000th,
-                // and the variable fee control is in basis points, so the result is in 400e18th
+                // The volatility accumulator is in basis points, binStep is in basis points,
+                // and the variable fee control is in basis points, so the result is in 100e18th
                 uint256 prod = uint256(getVolatilityAccumulator(params)) * binStep;
-                variableFee = (prod * prod * variableFeeControl + 399) / 400;
+                variableFee = (prod * prod * variableFeeControl + 99) / 100;
             }
         }
     }
@@ -252,10 +252,10 @@ library PairParameterHelper {
     /**
      * @dev Calculates the total fee, which is the sum of the base fee and the variable fee
      * @param params The encoded pair parameters
-     * @param binStep The bin step (in 20_000th)
+     * @param binStep The bin step (in basis points)
      * @return totalFee The total fee
      */
-    function getTotalFee(bytes32 params, uint8 binStep) internal pure returns (uint128) {
+    function getTotalFee(bytes32 params, uint16 binStep) internal pure returns (uint128) {
         unchecked {
             return (getBaseFee(params, binStep) + getVariableFee(params, binStep)).safe128();
         }

--- a/src/libraries/PriceHelper.sol
+++ b/src/libraries/PriceHelper.sol
@@ -25,7 +25,7 @@ library PriceHelper {
      * @param binStep The bin step
      * @return price The price as a 128.128-binary fixed-point number
      */
-    function getPriceFromId(uint24 id, uint8 binStep) internal pure returns (uint256 price) {
+    function getPriceFromId(uint24 id, uint16 binStep) internal pure returns (uint256 price) {
         uint256 base = getBase(binStep);
         int256 exponent = getExponent(id);
 
@@ -38,7 +38,7 @@ library PriceHelper {
      * @param binStep The bin step
      * @return id The id
      */
-    function getIdFromPrice(uint256 price, uint8 binStep) internal pure returns (uint24 id) {
+    function getIdFromPrice(uint256 price, uint16 binStep) internal pure returns (uint24 id) {
         uint256 base = getBase(binStep);
         int256 realId = price.log2() / base.log2();
 
@@ -52,9 +52,9 @@ library PriceHelper {
      * @param binStep The bin step
      * @return base The base
      */
-    function getBase(uint8 binStep) internal pure returns (uint256) {
+    function getBase(uint16 binStep) internal pure returns (uint256) {
         unchecked {
-            return Constants.SCALE + (uint256(binStep) << Constants.SCALE_OFFSET) / Constants.TWO_BASIS_POINT_MAX;
+            return Constants.SCALE + (uint256(binStep) << Constants.SCALE_OFFSET) / Constants.BASIS_POINT_MAX;
         }
     }
 

--- a/src/libraries/math/Encoded.sol
+++ b/src/libraries/math/Encoded.sol
@@ -40,6 +40,18 @@ library Encoded {
     }
 
     /**
+     * @notice Internal function to set a bool in an encoded bytes32 using an offset
+     * @dev This function can overflow
+     * @param encoded The previous encoded value
+     * @param boolean The bool to encode
+     * @param offset The offset
+     * @return newEncoded The new encoded value
+     */
+    function setBool(bytes32 encoded, bool boolean, uint256 offset) internal pure returns (bytes32 newEncoded) {
+        return set(encoded, boolean ? 1 : 0, MASK_UINT1, offset);
+    }
+
+    /**
      * @notice Internal function to decode a bytes32 sample using a mask and offset
      * @dev This function can overflow
      * @param encoded The encoded value
@@ -54,15 +66,15 @@ library Encoded {
     }
 
     /**
-     * @notice Internal function to decode a bytes32 sample into a uint1 using an offset
+     * @notice Internal function to decode a bytes32 sample into a bool using an offset
      * @dev This function can overflow
      * @param encoded The encoded value
      * @param offset The offset
-     * @return value The decoded value as a uint8, since uint1 is not supported
+     * @return boolean The decoded value as a bool
      */
-    function decodeUint1(bytes32 encoded, uint256 offset) internal pure returns (uint8 value) {
+    function decodeBool(bytes32 encoded, uint256 offset) internal pure returns (bool boolean) {
         assembly {
-            value := and(shr(offset, encoded), MASK_UINT1)
+            boolean := and(shr(offset, encoded), MASK_UINT1)
         }
     }
 

--- a/src/libraries/math/Uint128x128Math.sol
+++ b/src/libraries/math/Uint128x128Math.sol
@@ -106,7 +106,7 @@ library Uint128x128Math {
             }
         }
 
-        if (absY < 0x200000) {
+        if (absY < 0x100000) {
             result = Constants.SCALE;
             assembly {
                 let squared := x
@@ -154,8 +154,6 @@ library Uint128x128Math {
                 if and(absY, 0x40000) { result := shr(128, mul(result, squared)) }
                 squared := shr(128, mul(squared, squared))
                 if and(absY, 0x80000) { result := shr(128, mul(result, squared)) }
-                squared := shr(128, mul(squared, squared))
-                if and(absY, 0x100000) { result := shr(128, mul(result, shr(128, mul(result, squared)))) }
             }
         }
 

--- a/test/LBPairFees.t.sol
+++ b/test/LBPairFees.t.sol
@@ -481,6 +481,7 @@ contract LBPairFeesTest is TestHelper {
         vm.prank(BOB);
         wnative.transfer(address(pairWnative), 1e18);
         pairWnative.swap(true, BOB);
+        pairWnative.getBinStep();
 
         (uint128 protocolFeeX, uint128 protocolFeeY) = pairWnative.getProtocolFees();
         uint128 previousProtocolFeeX = protocolFeeX;
@@ -546,15 +547,15 @@ contract LBPairFeesTest is TestHelper {
     }
 
     function test_revert_TotalFeeExceeded(
-        uint8 binStep,
+        uint16 binStep,
         uint16 baseFactor,
         uint24 variableFeeControl,
         uint24 maxVolatilityAccumulator
     ) external {
         vm.assume(maxVolatilityAccumulator <= Encoded.MASK_UINT20);
 
-        uint256 baseFee = uint256(baseFactor) * binStep * 5e9;
-        uint256 varFee = ((uint256(binStep) * maxVolatilityAccumulator) ** 2 * variableFeeControl + 399) / 400;
+        uint256 baseFee = uint256(baseFactor) * binStep * 1e10;
+        uint256 varFee = ((uint256(binStep) * maxVolatilityAccumulator) ** 2 * variableFeeControl + 99) / 100;
 
         vm.assume(baseFee + varFee > 1e17);
 

--- a/test/LBPairImplementation.t.sol
+++ b/test/LBPairImplementation.t.sol
@@ -16,7 +16,7 @@ contract LBPairImplementationTest is Test {
         implementation = address(new LBPair(ILBFactory(factory)));
     }
 
-    function testFuzz_Getters(address tokenX, address tokenY, uint8 binStep) public {
+    function testFuzz_Getters(address tokenX, address tokenY, uint16 binStep) public {
         bytes32 salt = keccak256(abi.encodePacked(tokenX, tokenY, binStep));
         bytes memory data = abi.encodePacked(tokenX, tokenY, binStep);
 

--- a/test/LBRouter.Liquidity.t.sol
+++ b/test/LBRouter.Liquidity.t.sol
@@ -21,7 +21,7 @@ contract LiquidityBinRouterTest is TestHelper {
     function setUp() public override {
         super.setUp();
 
-        factory.setOpenPreset(DEFAULT_BIN_STEP, true);
+        factory.setPresetOpenState(DEFAULT_BIN_STEP, true);
 
         // Create necessary pairs
         router.createLBPair(usdt, usdc, ID_ONE, DEFAULT_BIN_STEP);
@@ -59,7 +59,7 @@ contract LiquidityBinRouterTest is TestHelper {
     function test_CreatePair() public {
         router.createLBPair(weth, usdc, ID_ONE, DEFAULT_BIN_STEP);
 
-        factory.setOpenPreset(DEFAULT_BIN_STEP, false);
+        factory.setPresetOpenState(DEFAULT_BIN_STEP, false);
 
         vm.expectRevert(
             abi.encodeWithSelector(

--- a/test/LBRouter.Swap.t.sol
+++ b/test/LBRouter.Swap.t.sol
@@ -21,7 +21,7 @@ contract LiquidityBinRouterSwapTest is TestHelper {
     function setUp() public override {
         super.setUp();
 
-        factory.setOpenPreset(DEFAULT_BIN_STEP, true);
+        factory.setPresetOpenState(DEFAULT_BIN_STEP, true);
 
         // Create necessary pairs
         router.createLBPair(usdt, usdc, ID_ONE, DEFAULT_BIN_STEP);

--- a/test/helpers/TestHelper.sol
+++ b/test/helpers/TestHelper.sol
@@ -39,7 +39,7 @@ abstract contract TestHelper is Test {
     uint256 internal constant BASIS_POINT_MAX = 10_000;
 
     // Avalanche market config for 10bps
-    uint8 internal constant DEFAULT_BIN_STEP = 20;
+    uint16 internal constant DEFAULT_BIN_STEP = 10;
     uint16 internal constant DEFAULT_BASE_FACTOR = 5_000;
     uint16 internal constant DEFAULT_FILTER_PERIOD = 30;
     uint16 internal constant DEFAULT_DECAY_PERIOD = 600;
@@ -47,6 +47,7 @@ abstract contract TestHelper is Test {
     uint24 internal constant DEFAULT_VARIABLE_FEE_CONTROL = 40_000;
     uint16 internal constant DEFAULT_PROTOCOL_SHARE = 1_000;
     uint24 internal constant DEFAULT_MAX_VOLATILITY_ACCUMULATOR = 350_000;
+    bool internal constant DEFAULT_OPEN_STATE = false;
     uint256 internal constant DEFAULT_FLASHLOAN_FEE = 8e14;
 
     address payable immutable DEV = payable(address(this));
@@ -196,7 +197,7 @@ abstract contract TestHelper is Test {
         if (address(taxToken) != address(0)) factory.addQuoteAsset(taxToken);
     }
 
-    function setDefaultFactoryPresets(uint8 binStep) internal {
+    function setDefaultFactoryPresets(uint16 binStep) internal {
         factory.setPreset(
             binStep,
             DEFAULT_BASE_FACTOR,
@@ -205,7 +206,8 @@ abstract contract TestHelper is Test {
             DEFAULT_REDUCTION_FACTOR,
             DEFAULT_VARIABLE_FEE_CONTROL,
             DEFAULT_PROTOCOL_SHARE,
-            DEFAULT_MAX_VOLATILITY_ACCUMULATOR
+            DEFAULT_MAX_VOLATILITY_ACCUMULATOR,
+            DEFAULT_OPEN_STATE
         );
     }
 
@@ -217,7 +219,7 @@ abstract contract TestHelper is Test {
         newPair = createLBPairFromStartIdAndBinStep(tokenX, tokenY, startId, DEFAULT_BIN_STEP);
     }
 
-    function createLBPairFromStartIdAndBinStep(IERC20 tokenX, IERC20 tokenY, uint24 startId, uint8 binStep)
+    function createLBPairFromStartIdAndBinStep(IERC20 tokenX, IERC20 tokenY, uint24 startId, uint16 binStep)
         internal
         returns (LBPair newPair)
     {
@@ -361,5 +363,9 @@ abstract contract TestHelper is Test {
         id = nbBinY > 0 ? id - nbBinY + 1 : id;
 
         return id.safe24();
+    }
+
+    function isPresetOpen(uint16 binStep) public view returns (bool isOpen) {
+        (,,,,,,, isOpen) = factory.getPreset(binStep);
     }
 }

--- a/test/libraries/BinHelper.t.sol
+++ b/test/libraries/BinHelper.t.sol
@@ -153,7 +153,7 @@ contract BinHelperTest is TestHelper {
     function testFuzz_GetCompositionFees(
         uint128 reserveX,
         uint128 reserveY,
-        uint8 binStep,
+        uint16 binStep,
         uint128 amountXIn,
         uint128 amountYIn,
         uint256 price,

--- a/test/libraries/ImmutableClone.t.sol
+++ b/test/libraries/ImmutableClone.t.sol
@@ -35,7 +35,7 @@ contract TestImmutableClone is Test {
         assertEq(implementationClone.getBytes(data.length), data, "testFuzz_Implementation::1");
     }
 
-    function testFuzz_Pair(address tokenX, address tokenY, uint8 binStep) public {
+    function testFuzz_Pair(address tokenX, address tokenY, uint16 binStep) public {
         address implementation = address(new Pair());
         bytes32 salt = keccak256("salt");
 
@@ -79,8 +79,8 @@ contract Pair is Clone {
         return _getArgAddress(20);
     }
 
-    function getBinStep() public pure returns (uint8) {
-        return _getArgUint8(40);
+    function getBinStep() public pure returns (uint16) {
+        return _getArgUint16(40);
     }
 }
 

--- a/test/libraries/PairParameterHelper.t.sol
+++ b/test/libraries/PairParameterHelper.t.sol
@@ -142,15 +142,15 @@ contract PairParameterHelperTest is Test {
         );
     }
 
-    function testFuzz_getBaseAndVariableFees(bytes32 params, uint8 binStep) external {
+    function testFuzz_getBaseAndVariableFees(bytes32 params, uint16 binStep) external {
         uint256 baseFee = params.getBaseFee(binStep);
         uint256 variableFee = params.getVariableFee(binStep);
 
-        assertEq(baseFee, uint256(params.getBaseFactor()) * binStep * 5e9, "test_getBaseAndVariableFees::1");
+        assertEq(baseFee, uint256(params.getBaseFactor()) * binStep * 1e10, "test_getBaseAndVariableFees::1");
 
         uint256 prod = uint256(params.getVolatilityAccumulator()) * binStep;
         assertEq(
-            variableFee, (prod * prod * params.getVariableFeeControl() + 399) / 400, "test_getBaseAndVariableFees::2"
+            variableFee, (prod * prod * params.getVariableFeeControl() + 99) / 100, "test_getBaseAndVariableFees::2"
         );
 
         if (baseFee + variableFee < type(uint128).max) {

--- a/test/libraries/math/Encoded.t.sol
+++ b/test/libraries/math/Encoded.t.sol
@@ -31,9 +31,9 @@ contract EncodedTest is Test {
         assertEq(v2, ((v << offset) >> offset) & mask, "test_SetAndDecode::1");
     }
 
-    function testFuzz_decodeUint1(bytes32 x, uint256 offset) external {
-        uint256 v = x.decodeUint1(offset);
-        assertEq(v, (uint256(x) >> offset) & 1, "test_decodeUint1::1");
+    function testFuzz_decodeBool(bytes32 x, uint256 offset) external {
+        bool v = x.decodeBool(offset);
+        assertEq(v ? 1 : 0, (uint256(x) >> offset) & 1, "test_decodeUint1::1");
     }
 
     function testFuzz_decodeUint8(bytes32 x, uint256 offset) external {


### PR DESCRIPTION
This PR is to allow the creation of more presets, from 1 to 65_535 as we may create pair with binstep > 100.
To make the pair more clear, the 0.5 precision on binstep was removed so `binStep = 1`, means 1bp.