### PR TITLE
Paladin audit

### DIFF
--- a/src/LBFactory.sol
+++ b/src/LBFactory.sol
@@ -227,6 +227,35 @@ contract LBFactory is PendingOwnable, ILBFactory {
     }
 
     /**
+     * @notice View function to return the list of open binSteps
+     * @return openBinStep The list of open binSteps
+     */
+    function getOpenBinSteps() external view override returns (uint256[] memory openBinStep) {
+        uint256 length = _presets.length();
+
+        if (length > 0) {
+            openBinStep = new uint256[](length);
+
+            uint256 index;
+
+            for (uint256 i; i < length; ++i) {
+                (uint256 binStep, uint256 preset) = _presets.at(i);
+
+                if (_isPresetOpen(bytes32(preset))) {
+                    openBinStep[index] = binStep;
+                    index++;
+                }
+            }
+
+            if (index < length) {
+                assembly {
+                    mstore(openBinStep, index)
+                }
+            }
+        }
+    }
+
+    /**
      * @notice View function to return all the LBPair of a pair of tokens
      * @param tokenX The first token of the pair
      * @param tokenY The second token of the pair

--- a/src/LBPair.sol
+++ b/src/LBPair.sol
@@ -382,7 +382,7 @@ contract LBPair is LBToken, ReentrancyGuard, Clone, ILBPair {
 
                 uint128 amountOutOfBin = binReserves > amountOutLeft ? amountOutLeft : binReserves;
 
-                parameters = parameters.updateVolatilityParameters(id);
+                parameters = parameters.updateVolatilityAccumulator(id);
 
                 uint128 amountInWithoutFee = uint128(
                     swapForY
@@ -485,9 +485,9 @@ contract LBPair is LBToken, ReentrancyGuard, Clone, ILBPair {
         bytes32 protocolFees = _protocolFees;
 
         bytes32 amountsLeft = swapForY ? reserves.receivedX(_tokenX()) : reserves.receivedY(_tokenY());
-        reserves = reserves.add(amountsLeft);
-
         if (amountsLeft == 0) revert LBPair__InsufficientAmountIn();
+
+        reserves = reserves.add(amountsLeft);
 
         bytes32 parameters = _parameters;
         uint16 binStep = _binStep();

--- a/src/LBPair.sol
+++ b/src/LBPair.sol
@@ -145,7 +145,6 @@ contract LBPair is LBToken, ReentrancyGuard, Clone, ILBPair {
      * @notice Returns the bin step of the Liquidity Book Pair
      * @dev The bin step is the increase in price between two consecutive bins, in basis points.
      * For example, a bin step of 1 means that the price of the next bin is 0.01% higher than the price of the previous bin.
-     * The maximum bin step is 200, which means that the price of the next bin is 1% higher than the price of the previous bin.
      * @return binStep The bin step of the Liquidity Book Pair, in 10_000th
      */
     function getBinStep() external pure override returns (uint16) {
@@ -615,8 +614,8 @@ contract LBPair is LBToken, ReentrancyGuard, Clone, ILBPair {
      * @dev Any excess amount of token will be sent to the `to` address.
      * @param to The address that will receive the LB tokens
      * @param liquidityConfigs The encoded liquidity configurations, each one containing the id of the bin and the
-     * @param refundTo The address that will receive the excess amount of tokens
      * percentage of token X and token Y to add to the bin.
+     * @param refundTo The address that will receive the excess amount of tokens
      * @return amountsReceived The amounts of token X and token Y received by the pool
      * @return amountsLeft The amounts of token X and token Y that were not added to the pool and were sent to `to`
      * @return liquidityMinted The amounts of LB tokens minted for each bin

--- a/src/LBToken.sol
+++ b/src/LBToken.sol
@@ -9,7 +9,7 @@ import {ILBToken} from "./interfaces/ILBToken.sol";
  * @author Trader Joe
  * @notice The LBToken is an implementation of a multi-token.
  * It allows to create multi-ERC20 represented by their ids.
- * Its implementation is really similar to the ERC1155 standardn the main difference
+ * Its implementation is really similar to the ERC1155 standard the main difference
  * is that it doesn't do any call to the receiver contract to prevent reentrancy.
  * As it's only for ERC20s, the uri function is not implemented.
  * The contract is made for batch operations.
@@ -115,10 +115,10 @@ abstract contract LBToken is ILBToken {
     }
 
     /**
-     * @notice Returns true if `spender` is approved to transfer `account`'s tokens.
+     * @notice Returns true if `spender` is approved to transfer `owner`'s tokens or if `spender` is the `owner`.
      * @param owner The address of the owner.
      * @param spender The address of the spender.
-     * @return True if `spender` is approved to transfer `account`'s tokens.
+     * @return True if `spender` is approved to transfer `owner`'s tokens.
      */
     function isApprovedForAll(address owner, address spender) public view virtual override returns (bool) {
         return _isApprovedForAll(owner, spender);
@@ -150,7 +150,7 @@ abstract contract LBToken is ILBToken {
     }
 
     /**
-     * @notice Returns true if `spender` is approved to transfer `owner`'s tokens or if `sender` is the `owner`.
+     * @notice Returns true if `spender` is approved to transfer `owner`'s tokens or if `spender` is the `owner`.
      * @param owner The address of the owner.
      * @param spender The address of the spender.
      * @return True if `spender` is approved to transfer `owner`'s tokens.

--- a/src/LBToken.sol
+++ b/src/LBToken.sol
@@ -97,7 +97,7 @@ abstract contract LBToken is ILBToken {
      * @param ids The token ids.
      * @return batchBalances The balance for each (account, id) pair.
      */
-    function balanceOfBatch(address[] memory accounts, uint256[] memory ids)
+    function balanceOfBatch(address[] calldata accounts, uint256[] calldata ids)
         public
         view
         virtual
@@ -140,7 +140,7 @@ abstract contract LBToken is ILBToken {
      * @param ids The list of token ids.
      * @param amounts The list of amounts to transfer for each token id in `ids`.
      */
-    function batchTransferFrom(address from, address to, uint256[] memory ids, uint256[] memory amounts)
+    function batchTransferFrom(address from, address to, uint256[] calldata ids, uint256[] calldata amounts)
         public
         virtual
         override
@@ -203,7 +203,7 @@ abstract contract LBToken is ILBToken {
      * @param ids The list of token ids.
      * @param amounts The list of amounts to transfer for each token id in `ids`.
      */
-    function _batchTransferFrom(address from, address to, uint256[] memory ids, uint256[] memory amounts)
+    function _batchTransferFrom(address from, address to, uint256[] calldata ids, uint256[] calldata amounts)
         internal
         checkLength(ids.length, amounts.length)
         notAddressZeroOrThis(to)

--- a/src/interfaces/ILBFactory.sol
+++ b/src/interfaces/ILBFactory.sol
@@ -118,6 +118,8 @@ interface ILBFactory is IPendingOwnable {
 
     function getAllBinSteps() external view returns (uint256[] memory presetsBinStep);
 
+    function getOpenBinSteps() external view returns (uint256[] memory openBinStep);
+
     function getAllLBPairs(IERC20 tokenX, IERC20 tokenY)
         external
         view

--- a/src/interfaces/ILBFactory.sol
+++ b/src/interfaces/ILBFactory.sol
@@ -22,7 +22,7 @@ interface ILBFactory is IPendingOwnable {
     error LBFactory__LBPairNotCreated(IERC20 tokenX, IERC20 tokenY, uint256 binStep);
     error LBFactory__FlashLoanFeeAboveMax(uint256 fees, uint256 maxFees);
     error LBFactory__BinStepTooLow(uint256 binStep);
-    error LBFactory__FunctionIsLockedForUsers(address user, uint256 binStep);
+    error LBFactory__PresetIsLockedForUsers(address user, uint256 binStep);
     error LBFactory__LBPairIgnoredIsAlreadyInTheSameState();
     error LBFactory__BinStepHasNoPreset(uint256 binStep);
     error LBFactory__PresetOpenStateIsAlreadyInTheSameState();

--- a/src/interfaces/ILBPair.sol
+++ b/src/interfaces/ILBPair.sol
@@ -28,6 +28,12 @@ interface ILBPair is ILBToken {
     error LBPair__ZeroShares(uint24 id);
     error LBPair__MaxTotalFeeExceeded();
 
+    struct MintArrays {
+        uint256[] ids;
+        bytes32[] amounts;
+        uint256[] liquidityMinted;
+    }
+
     event DepositedToBins(address indexed sender, address indexed to, uint256[] ids, bytes32[] amounts);
 
     event WithdrawnFromBins(address indexed sender, address indexed to, uint256[] ids, bytes32[] amounts);

--- a/src/libraries/BinHelper.sol
+++ b/src/libraries/BinHelper.sol
@@ -256,7 +256,7 @@ library BinHelper {
     }
 
     /**
-     * @dev Returns the encoded amounts that was transferred to the contract
+     * @dev Returns the encoded amounts that were transferred to the contract
      * @param reserves The reserves
      * @param tokenX The token X
      * @param tokenY The token Y
@@ -269,7 +269,7 @@ library BinHelper {
     }
 
     /**
-     * @dev Returns the encoded amounts that was transferred to the contract, only for token X
+     * @dev Returns the encoded amounts that were transferred to the contract, only for token X
      * @param reserves The reserves
      * @param tokenX The token X
      * @return amounts The amounts, encoded as follows:
@@ -282,7 +282,7 @@ library BinHelper {
     }
 
     /**
-     * @dev Returns the encoded amounts that was transferred to the contract, only for token Y
+     * @dev Returns the encoded amounts that were transferred to the contract, only for token Y
      * @param reserves The reserves
      * @param tokenY The token Y
      * @return amounts The amounts, encoded as follows:

--- a/src/libraries/Clone.sol
+++ b/src/libraries/Clone.sol
@@ -27,7 +27,7 @@ abstract contract Clone {
             mstore(arg, length)
             // Copy the array.
             calldatacopy(add(arg, 0x20), add(offset, argOffset), length)
-            // Allocate the memory, rounded up to the next 32 byte boudnary.
+            // Allocate the memory, rounded up to the next 32 byte boundary.
             mstore(0x40, and(add(add(arg, 0x3f), length), not(0x1f)))
         }
     }

--- a/src/libraries/PairParameterHelper.sol
+++ b/src/libraries/PairParameterHelper.sol
@@ -204,11 +204,11 @@ library PairParameterHelper {
     }
 
     /**
-     * @dev Get the delta between the active index and the reference index
+     * @dev Get the delta between the current active index and the cached active index
      * @param params The encoded pair parameters, as follows:
      * [0 - 232[: other parameters
      * [232 - 256[: active index (24 bits)
-     * @param activeId The active index
+     * @param activeId The current active index
      * @return The delta
      */
     function getDeltaId(bytes32 params, uint24 activeId) internal pure returns (uint24) {

--- a/src/libraries/PairParameterHelper.sol
+++ b/src/libraries/PairParameterHelper.sol
@@ -47,8 +47,6 @@ library PairParameterHelper {
 
     uint256 internal constant MASK_STATIC_PARAMETER = 0xffffffffffffffffffffffffffff;
 
-    uint256 internal constant MAX_PROTOCOL_SHARE = 2_500;
-
     /**
      * @dev Get the base factor from the encoded pair parameters
      * @param params The encoded pair parameters, as follows:
@@ -330,7 +328,7 @@ library PairParameterHelper {
     ) internal pure returns (bytes32 newParams) {
         if (
             filterPeriod > decayPeriod || decayPeriod > Encoded.MASK_UINT12
-                || reductionFactor > Constants.BASIS_POINT_MAX || protocolShare > MAX_PROTOCOL_SHARE
+                || reductionFactor > Constants.BASIS_POINT_MAX || protocolShare > Constants.MAX_PROTOCOL_SHARE
                 || maxVolatilityAccumulator > Encoded.MASK_UINT20
         ) revert PairParametersHelper__InvalidParameter();
 

--- a/src/libraries/PairParameterHelper.sol
+++ b/src/libraries/PairParameterHelper.sol
@@ -388,10 +388,12 @@ library PairParameterHelper {
      */
     function updateVolatilityAccumulator(bytes32 params, uint24 activeId) internal pure returns (bytes32) {
         uint256 idReference = getIdReference(params);
-        uint256 deltaId = activeId > idReference ? activeId - idReference : idReference - activeId;
 
+        uint256 deltaId;
         uint256 volAcc;
+
         unchecked {
+            deltaId = activeId > idReference ? activeId - idReference : idReference - activeId;
             volAcc = (uint256(getVolatilityReference(params)) + deltaId * Constants.BASIS_POINT_MAX);
         }
 

--- a/src/libraries/PendingOwnable.sol
+++ b/src/libraries/PendingOwnable.sol
@@ -10,7 +10,7 @@ import {IPendingOwnable} from "../interfaces/IPendingOwnable.sol";
  * @notice Contract module which provides a basic access control mechanism, where
  * there is an account (an owner) that can be granted exclusive access to
  * specific functions. The ownership of this contract is transferred using the
- * push and pull pattern, the current owner set a `pendingOwner` using
+ * push and pull pattern, the current owner sets a `pendingOwner` using
  * {setPendingOwner} and that address can then call {becomeOwner} to become the
  * owner of that contract. The main logic and comments comes from OpenZeppelin's
  * Ownable contract.

--- a/src/libraries/math/PackedUint128Math.sol
+++ b/src/libraries/math/PackedUint128Math.sol
@@ -93,13 +93,13 @@ library PackedUint128Math {
     /**
      * @dev Decodes a bytes32 into a uint128 as the first uint128
      * @param z The encoded bytes32 as follows:
-     * [0 - 128[: x1
+     * [0 - 128[: x
      * [128 - 256[: any
-     * @return x1 The first uint128
+     * @return x The first uint128
      */
-    function decodeX(bytes32 z) internal pure returns (uint128 x1) {
+    function decodeX(bytes32 z) internal pure returns (uint128 x) {
         assembly {
-            x1 := and(z, MASK_128)
+            x := and(z, MASK_128)
         }
     }
 
@@ -107,12 +107,12 @@ library PackedUint128Math {
      * @dev Decodes a bytes32 into a uint128 as the second uint128
      * @param z The encoded bytes32 as follows:
      * [0 - 128[: any
-     * [128 - 256[: x2
-     * @return x2 The second uint128
+     * [128 - 256[: y
+     * @return y The second uint128
      */
-    function decodeY(bytes32 z) internal pure returns (uint128 x2) {
+    function decodeY(bytes32 z) internal pure returns (uint128 y) {
         assembly {
-            x2 := shr(OFFSET, z)
+            y := shr(OFFSET, z)
         }
     }
 
@@ -207,7 +207,7 @@ library PackedUint128Math {
     }
 
     /**
-     * @dev Returns whether any of the uint128 of x is greater than the corresponding uint128 of y
+     * @dev Returns whether any of the uint128 of x is strictly greater than the corresponding uint128 of y
      * @param x The first bytes32 encoded as follows:
      * [0 - 128[: x1
      * [128 - 256[: x2
@@ -224,7 +224,7 @@ library PackedUint128Math {
     }
 
     /**
-     * @dev Returns whether any of the uint128 of x is greater than or equal to the corresponding uint128 of y
+     * @dev Returns whether any of the uint128 of x is strictly greater than the corresponding uint128 of y
      * @param x The first bytes32 encoded as follows:
      * [0 - 128[: x1
      * [128 - 256[: x2
@@ -238,36 +238,6 @@ library PackedUint128Math {
         (uint128 y1, uint128 y2) = decode(y);
 
         return x1 > y1 || x2 > y2;
-    }
-
-    /**
-     * @dev Multiplies an encoded bytes32 by a uint256 then shifts the result 128 bits to the right, rounding up
-     * @param x The bytes32 encoded as follows:
-     * [0 - 128[: x1
-     * [128 - 256[: x2
-     * @param multiplier The uint128 to multiply by
-     * @return z The product of x and multiplier encoded as follows:
-     * [0 - 128[: ceil((x1 * multiplier) / 2**128)
-     * [128 - 256[: ceil((x2 * multiplier) / 2**128)
-     */
-    function scalarMulShiftRoundUp(bytes32 x, uint256 multiplier) internal pure returns (bytes32 z) {
-        if (multiplier == 0) return 0;
-        if (multiplier > MASK_128_PLUS_ONE) revert PackedUint128Math__MultiplierTooLarge();
-
-        (uint128 x1, uint128 x2) = decode(x);
-
-        // Can't overflow because:
-        // ```
-        // max(x{1,2} * multiplier) = type(uint128).max * type(uint128).max
-        //                      = type(uint256).max - (2**129 - 2)
-        // MASK_128 = 2**128 - 1 < 2**129 - 2
-        // ```
-        assembly {
-            x1 := shr(OFFSET, add(mul(x1, multiplier), MASK_128))
-            x2 := shr(OFFSET, add(mul(x2, multiplier), MASK_128))
-        }
-
-        return encode(x1, x2);
     }
 
     /**

--- a/test/LBPairFlashloan.t.sol
+++ b/test/LBPairFlashloan.t.sol
@@ -102,4 +102,24 @@ contract LBPairFlashloanTest is TestHelper {
         vm.expectRevert(ILBPair.LBPair__ZeroBorrowAmount.selector);
         pairWnative.flashLoan(borrower, 0, "");
     }
+
+    function test_EdgeCaseFlashLoanBinDOS() external {
+        // remove the active liquidity
+        removeLiquidity(DEV, DEV, pairWnative, ID_ONE, 1e18, 1, 1);
+
+        bytes32 amountsBorrowed = uint128(1e17).encode(uint128(1e17));
+        bytes memory data = abi.encode(type(uint128).max, type(uint128).max, Constants.CALLBACK_SUCCESS, 0);
+
+        pairWnative.flashLoan(borrower, amountsBorrowed, data);
+
+        (uint256 x, uint256 y) = pairWnative.getBin(ID_ONE);
+
+        assertEq(x, 0, "test_EdgeCaseFlashLoanBinDOS::1");
+        assertEq(y, 0, "test_EdgeCaseFlashLoanBinDOS::2");
+
+        addLiquidity(DEV, DEV, pairWnative, ID_ONE, 1e18, 1e18, 1, 1);
+
+        assertEq(pairWnative.getNextNonEmptyBin(true, ID_ONE + 1), ID_ONE, "test_EdgeCaseFlashLoanBinDOS::3");
+        assertEq(pairWnative.getNextNonEmptyBin(false, ID_ONE - 1), ID_ONE, "test_EdgeCaseFlashLoanBinDOS::4");
+    }
 }

--- a/test/LBPairFlashloan.t.sol
+++ b/test/LBPairFlashloan.t.sol
@@ -89,12 +89,10 @@ contract LBPairFlashloanTest is TestHelper {
     }
 
     function testFuzz_revert_FlashLoanReentrant(bytes32 callback) external {
-        vm.assume(callback != Constants.CALLBACK_SUCCESS);
-
         bytes32 amountsBorrowed = bytes32(uint256(1));
         bytes memory data = abi.encode(0, 0, callback, 1);
 
-        vm.expectRevert(ReentrancyGuard.ReentrancyGuard__ReentrantCall.selector);
+        vm.expectRevert(ILBPair.LBPair__FlashLoanCallbackFailed.selector);
         pairWnative.flashLoan(borrower, amountsBorrowed, data);
     }
 

--- a/test/LBPairLiquidity.t.sol
+++ b/test/LBPairLiquidity.t.sol
@@ -333,6 +333,8 @@ contract LBPairLiquidityTest is TestHelper {
         ids[0] = activeId;
         balances[0] = 1;
 
+        addLiquidity(DEV, DEV, pairWnative, activeId, 1e18, 1e18, 1, 1);
+
         vm.expectRevert(abi.encodeWithSelector(ILBPair.LBPair__ZeroAmountsOut.selector, activeId));
         pairWnative.burn(DEV, DEV, ids, balances);
     }

--- a/test/LBRouter.Liquidity.t.sol
+++ b/test/LBRouter.Liquidity.t.sol
@@ -63,7 +63,7 @@ contract LiquidityBinRouterTest is TestHelper {
 
         vm.expectRevert(
             abi.encodeWithSelector(
-                ILBFactory.LBFactory__FunctionIsLockedForUsers.selector, address(router), DEFAULT_BIN_STEP
+                ILBFactory.LBFactory__PresetIsLockedForUsers.selector, address(router), DEFAULT_BIN_STEP
             )
         );
         router.createLBPair(bnb, usdc, ID_ONE, DEFAULT_BIN_STEP);

--- a/test/LBToken.t.sol
+++ b/test/LBToken.t.sol
@@ -302,9 +302,6 @@ contract LBTokenTest is Test {
         vm.assume(ids.length != amounts.length && ids.length != 0);
 
         vm.expectRevert(abi.encodeWithSelector(ILBToken.LBToken__InvalidLength.selector));
-        lbToken.mintBatch(address(1), ids, amounts);
-
-        vm.expectRevert(abi.encodeWithSelector(ILBToken.LBToken__InvalidLength.selector));
         vm.prank(address(1));
         lbToken.batchTransferFrom(address(1), address(2), ids, amounts);
     }
@@ -361,10 +358,16 @@ contract LBTokenTest is Test {
 
 contract LBTokenCoverage is LBToken {
     function mintBatch(address to, uint256[] calldata ids, uint256[] calldata amounts) external {
-        _mintBatch(to, ids, amounts);
+        // _mintBatch(to, ids, amounts);
+        for (uint256 i = 0; i < ids.length; i++) {
+            _mint(to, ids[i], amounts[i]);
+        }
     }
 
     function batchBurnFrom(address from, uint256[] calldata ids, uint256[] calldata amounts) external {
-        _burnBatch(from, ids, amounts);
+        // _batchBurnFrom(from, ids, amounts);
+        for (uint256 i = 0; i < ids.length; i++) {
+            _burn(from, ids[i], amounts[i]);
+        }
     }
 }

--- a/test/LBToken.t.sol
+++ b/test/LBToken.t.sol
@@ -219,7 +219,8 @@ contract LBTokenTest is Test {
 
     function testFuzz_ApprovedForAll(address from, address to, uint256 id, uint256 amount) external {
         vm.assume(
-            from != address(0) && to != address(lbToken) && to != address(0) && to != address(lbToken) && from != to
+            from != address(lbToken) && from != address(0) && to != address(lbToken) && to != address(0)
+                && to != address(lbToken) && from != to
         );
 
         uint256[] memory ids = new uint256[](1);

--- a/test/libraries/FeeHelper.t.sol
+++ b/test/libraries/FeeHelper.t.sol
@@ -13,7 +13,7 @@ contract FeeHelperTest is Test {
 
     function testFuzz_GetFeeAmountFrom(uint128 amountWithFee, uint128 fee) external {
         if (fee > Constants.MAX_FEE) {
-            vm.expectRevert(FeeHelper.FeeHelper__FeeOverflow.selector);
+            vm.expectRevert(FeeHelper.FeeHelper__FeeTooLarge.selector);
             amountWithFee.getFeeAmountFrom(fee);
         } else {
             uint256 expectedFeeAmount = (uint256(amountWithFee) * fee + 1e18 - 1) / 1e18;
@@ -25,7 +25,7 @@ contract FeeHelperTest is Test {
 
     function testFuzz_GetFeeAmount(uint128 amount, uint128 fee) external {
         if (fee > Constants.MAX_FEE) {
-            vm.expectRevert(FeeHelper.FeeHelper__FeeOverflow.selector);
+            vm.expectRevert(FeeHelper.FeeHelper__FeeTooLarge.selector);
             amount.getFeeAmount(fee);
         } else {
             uint128 denominator = 1e18 - fee;
@@ -39,7 +39,7 @@ contract FeeHelperTest is Test {
 
     function testFuzz_GetCompositionFee(uint128 amountWithFee, uint128 fee) external {
         if (fee > Constants.MAX_FEE) {
-            vm.expectRevert(FeeHelper.FeeHelper__FeeOverflow.selector);
+            vm.expectRevert(FeeHelper.FeeHelper__FeeTooLarge.selector);
             amountWithFee.getCompositionFee(fee);
         }
 
@@ -54,7 +54,7 @@ contract FeeHelperTest is Test {
 
     function testFuzz_GetProtocolFeeAmount(uint128 amount, uint128 fee) external {
         if (fee > Constants.MAX_PROTOCOL_SHARE) {
-            vm.expectRevert(FeeHelper.FeeHelper__ProtocolShareOverflow.selector);
+            vm.expectRevert(FeeHelper.FeeHelper__ProtocolShareTooLarge.selector);
             amount.getProtocolFeeAmount(fee);
         } else {
             uint256 expectedProtocolFeeAmount = (uint256(amount) * fee) / 1e4;

--- a/test/libraries/PairParameterHelper.t.sol
+++ b/test/libraries/PairParameterHelper.t.sol
@@ -22,8 +22,7 @@ contract PairParameterHelperTest is Test {
     function testFuzz_StaticFeeParametersDirtyBits(bytes32 params, StaticFeeParameters memory sfp) external {
         vm.assume(
             sfp.filterPeriod <= sfp.decayPeriod && sfp.decayPeriod <= Encoded.MASK_UINT12
-                && sfp.reductionFactor <= Constants.BASIS_POINT_MAX
-                && sfp.protocolShare <= PairParameterHelper.MAX_PROTOCOL_SHARE
+                && sfp.reductionFactor <= Constants.BASIS_POINT_MAX && sfp.protocolShare <= Constants.MAX_PROTOCOL_SHARE
                 && sfp.maxVolatilityAccumulator <= Encoded.MASK_UINT20
         );
 
@@ -61,8 +60,7 @@ contract PairParameterHelperTest is Test {
     function testFuzz_StaticFeeParameters(bytes32 params, StaticFeeParameters memory sfp) external {
         vm.assume(
             sfp.filterPeriod <= sfp.decayPeriod && sfp.decayPeriod <= Encoded.MASK_UINT12
-                && sfp.reductionFactor <= Constants.BASIS_POINT_MAX
-                && sfp.protocolShare <= PairParameterHelper.MAX_PROTOCOL_SHARE
+                && sfp.reductionFactor <= Constants.BASIS_POINT_MAX && sfp.protocolShare <= Constants.MAX_PROTOCOL_SHARE
                 && sfp.maxVolatilityAccumulator <= Encoded.MASK_UINT20
         );
 
@@ -96,8 +94,7 @@ contract PairParameterHelperTest is Test {
     function testFuzz_revert_StaticFeeParameters(bytes32 params, StaticFeeParameters memory sfp) external {
         vm.assume(
             sfp.filterPeriod > sfp.decayPeriod || sfp.decayPeriod > Encoded.MASK_UINT12
-                || sfp.reductionFactor > Constants.BASIS_POINT_MAX
-                || sfp.protocolShare > PairParameterHelper.MAX_PROTOCOL_SHARE
+                || sfp.reductionFactor > Constants.BASIS_POINT_MAX || sfp.protocolShare > Constants.MAX_PROTOCOL_SHARE
                 || sfp.maxVolatilityAccumulator > Encoded.MASK_UINT20
         );
 
@@ -269,8 +266,7 @@ contract PairParameterHelperTest is Test {
     {
         vm.assume(
             previousTime <= time && sfp.filterPeriod <= sfp.decayPeriod && sfp.decayPeriod <= Encoded.MASK_UINT12
-                && sfp.reductionFactor <= Constants.BASIS_POINT_MAX
-                && sfp.protocolShare <= PairParameterHelper.MAX_PROTOCOL_SHARE
+                && sfp.reductionFactor <= Constants.BASIS_POINT_MAX && sfp.protocolShare <= Constants.MAX_PROTOCOL_SHARE
                 && sfp.maxVolatilityAccumulator <= Encoded.MASK_UINT20
         );
 
@@ -333,8 +329,7 @@ contract PairParameterHelperTest is Test {
     ) external {
         vm.assume(
             previousTime <= time && sfp.filterPeriod <= sfp.decayPeriod && sfp.decayPeriod <= Encoded.MASK_UINT12
-                && sfp.reductionFactor <= Constants.BASIS_POINT_MAX
-                && sfp.protocolShare <= PairParameterHelper.MAX_PROTOCOL_SHARE
+                && sfp.reductionFactor <= Constants.BASIS_POINT_MAX && sfp.protocolShare <= Constants.MAX_PROTOCOL_SHARE
                 && sfp.maxVolatilityAccumulator <= Encoded.MASK_UINT20
         );
 

--- a/test/libraries/math/PackedUint128Math.t.sol
+++ b/test/libraries/math/PackedUint128Math.t.sol
@@ -148,30 +148,6 @@ contract PackedUint128MathTest is Test {
         assertEq(x.gt(y), x1 > y1 || x2 > y2, "testFuzz_GreaterThan::1");
     }
 
-    function testFuzz_ScalarMulShiftRoundUp(bytes32 x, uint128 multiplier) external {
-        (uint128 x1, uint128 x2) = x.decode();
-
-        uint256 y1 = uint256(x1) * multiplier;
-        uint256 y2 = uint256(x2) * multiplier;
-
-        uint256 z1 = y1 == 0 ? 0 : ((y1 - 1) >> 128) + 1;
-        uint256 z2 = y2 == 0 ? 0 : ((y2 - 1) >> 128) + 1;
-
-        assertLe(z1, type(uint128).max, "testFuzz_ScalarMulShiftRoundUp::1");
-        assertLe(z2, type(uint128).max, "testFuzz_ScalarMulShiftRoundUp::2");
-
-        assertEq(
-            x.scalarMulShiftRoundUp(multiplier), uint128(z1).encode(uint128(z2)), "testFuzz_ScalarMulShiftRoundUp::3"
-        );
-    }
-
-    function testFuzz_revert_ScalarMulShiftRoundUp(bytes32 x, uint256 multiplier) external {
-        vm.assume(multiplier > uint256(type(uint128).max) + 1);
-
-        vm.expectRevert(PackedUint128Math.PackedUint128Math__MultiplierTooLarge.selector);
-        x.scalarMulShiftRoundUp(multiplier);
-    }
-
     function testFuzz_ScalarMulDivBasisPointRoundDown(bytes32 x, uint128 multipilier) external {
         (uint128 x1, uint128 x2) = x.decode();
 


### PR DESCRIPTION
# LB V2.1 prelim audits

## LBFactory

### Issue 01: Missing visibility for open presets

Added the `getOpenBinSteps` function that iterates over the binsteps and return the opened binsteps.

### Issue 02: getAllBinSteps and getAllLBPairs can run out of gas

We're okay with this, the number of pairs should never exceeds a reasonable number (It should never exceeds 10) , that will be far less than the gas limit.
We will keep the number of opened preset limited to make sure that bad actors can't make those functions revert by creating a lot of pairs.

### Issue 03: Typographical errors

All fixed but the last one as it is in fact validated by solidity itself.

### Issue 04: Gas optimization

`owner()` is now cached, had to move the implementation check to avoid stack too deep error, also fixed a small typo error.

## LBPair

### Issue 05: An exploiter can disable bins permanently through a multi-step exploit if these bins were not yet in use

The three adds and remove depending on the supply, not on the reserves.
The flashloan fees are all sent to the protocol if the bin has no supply.

### Issue 06: mint and burn mint insufficient tokens if the same token id is used twice within a single call

Moved the lbtoken to `mint` and `burn`, but without emitting events (to save a ton of gas), the events are emitted in the pair itself.
Had to do some changes on the pair to avoid stack too deep error.

### Issue 07: Flashloans can be sandwich-attacked

We're aware of this possibility and we're fine with it.

### Issue 08: Swaps can be frontrun by liquidity providers

We're aware of this and we're completely fine with it as this would just mean some more active LP.

### Issue 09: getOracleSampleAt returns incorrect cumulativeId

We now use the `activeId` instead of the `idRef`.

### Issue 10: Governance risk: Factory owner can DoS flashloans

The factory will indeed be owned by our multisig.

### Issue 11: Typographical errors:

- Removed this line as there is the limit was kind of removed
- This is wrong, the `_reserves` do have the protocol fees, e.g L408 `reserves = reserves.add(amountsLeft);`, amountLeft is the full amount sent by the user, including the fees for LP and the fees for the protocol.
- Reordered the lines

### Issue 12: Events are not compliant with checks-effects-interactions

We follow OZ rules, and they tend to emit the events at the very end of the functions.
Furthermore, I don't think this can happen within LB as the functions that could allow some reentrancy are protected by the `nonReentrant` modifier.

### Issue 13: The flashloan callback fail error will often not be thrown

Moved to a low level call

### Issue 14: Gas optimizations

Fixed both

## LBToken

### Issue 15: No possibility to transfer single IDs

Acknowledged, we don't believe adding this is worth to add as this would increase the overall complexity of the token

### Issue 16: Gas optimization

The `_mintBatch` and `_burnBatch` were removed from the contract.
The `balanceOfBatch`, `batchTransferFrom` and `_batchTransferFrom` moved to calldata

### Issue 17: Typographical errors

- fixed
- fixed
- fixed
- This is intentional to avoid the scary red message from metamask saying that if you approve this function, all your NFT could get stolen
- We'll keep them

## LiquidityConfiguration

### Issue 18: Encoding might encode dirty bits

The library now uses the `Encoded` library to make sure the dirty bits are cleaned.

## PackedUint128Math

### Issue 19: Encoding might encode dirty bits

The library now uses `and(x1, MASK_128)` to make sure the dirty bits are cleaned.

### Issue 20: Typographical errors

- We're keeping `decodeX` and `decodeY` as we believe this makes it easier to understand in the code itself. However, we fixed the different variables name to be consistent inside the function.
- Fixed
- The `scalarMulShiftRoundUp` was removed.

## Sample Math

### Issue 21: Encoding might encode dirty bits

The library now uses the `Encoded` library to make sure the dirty bits are cleaned.

### Issue 22: Early return in getWeightedAverage can be flawed

The recommendation would create a div by zero error if both weights are zero, this is the case when one of the sample has exactly the same timestamp as the lookup one.
In this case, (where both samples are the same), the weights would also be zero but it should return the sample.
We're acknowledging this one.

## BinHelper

### Issue 23: Typographical errors

Fixed

### Issue 24: Gas optimizations

- fixed
- added the `getLiquidity` function taking x and y directly

## Clone

### Issue 25: Typographical error

fixed (funny cause this typo comes from the official library)

## FeeHelper

### Issue 26: Typographical errors

- Import was removed
- Renamed `overflow` to `tooLarge`

## OracleHelper

### Issue 27: First sample will be empty

Acknowledged

## PairParameterHelper

### Issue 28: Encoding might encode dirty bits

The library now uses the `Encoded` library to make sure the dirty bits are cleaned.

### Issue 29: Manual intervention for forceDecay is necessary

Acknowledged

### Issue 30: Small reductionFactor rounds down volRef

Acknowledged, rounding down the volatility reference is fine for us

### Issue 31: getDeltaId implementation appears to be wrong

The comments have been updated

### Issue 32: Typographical issue

fixed

### Issue 33: Gas optimizations

fixed

## PendingOwnable

### Issue 34: Typographical issue

fixed

### Issue 35: Gas optimizations

Acknowledged
