### PR TITLE
fix liquidity parameters documentation

### DIFF
--- a/src/interfaces/ILBRouter.sol
+++ b/src/interfaces/ILBRouter.sol
@@ -67,8 +67,8 @@ interface ILBRouter {
      * - activeIdDesired: The active id that user wants to add liquidity from
      * - idSlippage: The number of id that are allowed to slip
      * - deltaIds: The list of delta ids to add liquidity (`deltaId = activeId - desiredId`)
-     * - distributionX: The distribution of tokenX with sum(distributionX) = 100e18 (100%) or 0 (0%)
-     * - distributionY: The distribution of tokenY with sum(distributionY) = 100e18 (100%) or 0 (0%)
+     * - distributionX: The distribution of tokenX with sum(distributionX) = 1e18 (100%) or 0 (0%)
+     * - distributionY: The distribution of tokenY with sum(distributionY) = 1e18 (100%) or 0 (0%)
      * - to: The address of the recipient
      * - refundTo: The address of the recipient of the refunded tokens if too much tokens are sent
      * - deadline: The deadline of the transaction


### PR DESCRIPTION
The code doc is wrong, the [code example](https://docs.traderjoexyz.com/guides/add-remove-liquidity#code-example) is right.